### PR TITLE
FunBlocks update - Let blocks and fixes

### DIFF
--- a/funblocks-client/src/Blockly/Block.hs
+++ b/funblocks-client/src/Blockly/Block.hs
@@ -26,6 +26,7 @@ module Blockly.Block ( Block(..)
                      , select
                      , addSelect
                      , addErrorSelect
+                     , setWarningText
                      , getInputBlock)
   where
 
@@ -81,6 +82,8 @@ addSelect block = js_addSelect block
 addErrorSelect :: Block -> IO ()
 addErrorSelect block = js_addErrorSelect block
 
+setWarningText :: Block -> String -> IO ()
+setWarningText block text = js_setWarningText block (pack text)
 
 --- FFI
 
@@ -114,6 +117,9 @@ foreign import javascript unsafe "$1.addSelect()"
 
 foreign import javascript unsafe "$1.addErrorSelect()"
   js_addErrorSelect :: Block -> IO ()
+
+foreign import javascript unsafe "$1.setWarningText($2)"
+  js_setWarningText :: Block -> JSString -> IO ()
 
 -- fetches the block associated with the input name or else null
 foreign import javascript unsafe "$1.getInputTargetBlock($2)"

--- a/funblocks-client/src/Blockly/Block.hs
+++ b/funblocks-client/src/Blockly/Block.hs
@@ -24,10 +24,12 @@ module Blockly.Block ( Block(..)
                      , getOutputConnection
                      , getColour
                      , setColour
+                     , areAllInputsConnected
                      , select
                      , addSelect
                      , addErrorSelect
                      , setWarningText
+                     , disableWarningText
                      , setDisabled
                      , getInputBlock)
   where
@@ -83,19 +85,25 @@ getInputBlock block name = if isNull val then Nothing
   where val = js_getInputTargetBlock block (pack name)
 
 select :: Block -> IO ()
-select block = js_select block
+select = js_select 
 
 addSelect :: Block -> IO ()
-addSelect block = js_addSelect block
+addSelect = js_addSelect 
 
 addErrorSelect :: Block -> IO ()
-addErrorSelect block = js_addErrorSelect block
+addErrorSelect = js_addErrorSelect 
 
 setWarningText :: Block -> String -> IO ()
 setWarningText block text = js_setWarningText block (pack text)
 
+disableWarningText :: Block ->  IO ()
+disableWarningText = js_disableWarningText 
+
 setDisabled :: Block -> Bool -> IO ()
-setDisabled block stat = js_setDisabled block stat
+setDisabled = js_setDisabled 
+
+areAllInputsConnected :: Block -> Bool
+areAllInputsConnected = js_allInputsConnected
 
 --- FFI
 
@@ -111,6 +119,9 @@ foreign import javascript unsafe "$1.outputConnection"
 
 foreign import javascript unsafe "$1.outputConnection"
   js_outputConnection :: Block -> Connection
+
+foreign import javascript unsafe "$1.allInputsConnected()"
+  js_allInputsConnected :: Block -> Bool
 
 foreign import javascript unsafe "$1.targetBlock()"
   js_outputConnectionBlock' :: JSVal -> JSVal
@@ -141,6 +152,10 @@ foreign import javascript unsafe "$1.addErrorSelect()"
 
 foreign import javascript unsafe "$1.setWarningText($2)"
   js_setWarningText :: Block -> JSString -> IO ()
+
+foreign import javascript unsafe "$1.setWarningText(null)"
+  js_disableWarningText :: Block -> IO ()
+
 
 -- fetches the block associated with the input name or else null
 foreign import javascript unsafe "$1.getInputTargetBlock($2)"

--- a/funblocks-client/src/Blockly/Connection.hs
+++ b/funblocks-client/src/Blockly/Connection.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE JavaScriptFFI #-}
+
+{-
+  Copyright 2016 The CodeWorld Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-}
+
+module Blockly.Connection ( Connection(..) )
+  where
+
+import GHCJS.Types
+import GHCJS.Foreign
+import GHCJS.Marshal
+
+newtype Connection = Connection JSVal
+
+instance IsJSVal Connection
+
+instance ToJSVal Connection where
+  toJSVal (Connection v) = return v
+
+instance FromJSVal Connection where
+  fromJSVal v = return $ Just $ Connection v
+

--- a/funblocks-client/src/Blockly/Workspace.hs
+++ b/funblocks-client/src/Blockly/Workspace.hs
@@ -20,6 +20,7 @@
 module Blockly.Workspace ( Workspace(..)
                           ,setWorkspace
                           ,workspaceToCode
+                          ,isTopBlock
                           ,getById
                           ,getBlockById
                           )
@@ -58,14 +59,20 @@ getBlockById workspace (UUID uuidstr) = if isNull val then Nothing
                                         else Just $ unsafeCoerce val
   where val = js_getBlockById workspace (pack uuidstr)
 
+isTopBlock :: Workspace -> Block -> Bool
+isTopBlock = js_isTopBlock
+
 --- FFI
 
 -- TODO Maybe use a list of properties ?
-foreign import javascript unsafe "Blockly.inject($1, { toolbox: document.getElementById($2), css: false, comments: false, zoom:{wheel:true, controls: true}})"
+foreign import javascript unsafe "Blockly.inject($1, { toolbox: document.getElementById($2), css: false, disabled: false, comments: false, zoom:{wheel:true, controls: true}})"
   js_blocklyInject :: JSString -> JSString -> IO Workspace
 
 foreign import javascript unsafe "Blockly.FunBlocks.workspaceToCode($1)"
   js_blocklyWorkspaceToCode :: Workspace -> IO JSString
+
+foreign import javascript unsafe "$1.isTopBlock($2)"
+  js_isTopBlock :: Workspace -> Block -> Bool 
 
 foreign import javascript unsafe "Blockly.Workspace.getById($1)"
   js_getById :: JSString -> Workspace

--- a/funblocks-client/src/Blockly/Workspace.hs
+++ b/funblocks-client/src/Blockly/Workspace.hs
@@ -61,7 +61,7 @@ getBlockById workspace (UUID uuidstr) = if isNull val then Nothing
 --- FFI
 
 -- TODO Maybe use a list of properties ?
-foreign import javascript unsafe "Blockly.inject($1, { toolbox: document.getElementById($2), css: false, comments: false})"
+foreign import javascript unsafe "Blockly.inject($1, { toolbox: document.getElementById($2), css: false, comments: false, zoom:{wheel:true, controls: true}})"
   js_blocklyInject :: JSString -> JSString -> IO Workspace
 
 foreign import javascript unsafe "Blockly.FunBlocks.workspaceToCode($1)"

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -260,7 +260,7 @@ blockLCM block = do
 blockString :: GeneratorFunction
 blockString block = do 
     let txt = getFieldValue block "TEXT" 
-    return $ none $ "\"" ++ txt ++ "\""
+    return $ none $ escape txt 
 
 blockConcat :: GeneratorFunction
 blockConcat block = do 
@@ -614,6 +614,16 @@ valueToCode block name ordr =
     case unpack $ js_valueToCode block (pack name) (order ordr) of
       "" ->  Left block
       val -> Right val
+
+
+-- Helper functions
+
+-- Escapes a string
+escape :: String -> String
+escape xs = "\"" ++ concatMap f xs ++ "\"" where
+    f '\\' = "\\\\"
+    f '\"' = "\\\""
+    f x    = [x]
 
 --- FFI
 foreign import javascript unsafe "Blockly.FunBlocks[$1] = $2"

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -594,7 +594,7 @@ setCodeGen blockName func = do
                                     Right (code,ordr) -> do
                                             return $ js_makeArray (pack code) (order ordr)
                                     Left eblock -> do
-                                            -- setWarningText eblock "Block must have input"
+                                            setWarningText eblock "Block contains an input field that is disconnected"
                                             addErrorSelect eblock
                                             js_removeErrorsDelay
                                             return $ js_makeArray (pack "") 0
@@ -653,7 +653,7 @@ foreign import javascript unsafe "Blockly.FunBlocks.valueToCode($1, $2, $3)"
 foreign import javascript unsafe "[$1,$2]"
   js_makeArray :: JSString -> Int -> JSVal
 
-foreign import javascript unsafe "setTimeout(removeErrors,5000)"
+foreign import javascript unsafe "setTimeout(removeErrors,10000)"
   js_removeErrorsDelay :: IO ()
 
 -- TODO, remove, was used for testing

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -610,10 +610,26 @@ assignAll :: IO ()
 assignAll = mapM_ (uncurry setCodeGen) blockCodeMap
 
 valueToCode :: Block -> String -> OrderConstant -> Either Block String
-valueToCode block name ordr =  
-    case unpack $ js_valueToCode block (pack name) (order ordr) of
-      "" ->  Left block
-      val -> Right val
+valueToCode block name innerOrder = do
+    inputBlock <- aux $ getInputBlock block name
+    let blockType = getBlockType inputBlock
+    func <- aux $ lookup blockType blockCodeMap
+    (code,ordr) <- func inputBlock
+    Right $ handleOrder ordr code
+  where
+    aux m = case m of
+      Just v -> Right v
+      Nothing -> Left block
+    handleOrder CAtomic code = code
+    handleOrder CNone code = code
+    handleOrder _ code = "(" ++ code ++ ")"
+
+-- valueToCode :: Block -> String -> OrderConstant -> Either Block String
+-- valueToCode block name ordr =  
+--     case unpack $ js_valueToCode block (pack name) (order ordr) of
+--       "" ->  Left block
+--       val -> Right val
+
 
 
 -- Helper functions

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -587,6 +587,7 @@ setCodeGen blockName func = do
                                     Right (code,ordr) -> do
                                             return $ js_makeArray (pack code) (order ordr)
                                     Left eblock -> do
+                                            -- setWarningText eblock "Block must have input"
                                             addErrorSelect eblock
                                             js_removeErrorsDelay
                                             return $ js_makeArray (pack "") 0
@@ -606,12 +607,6 @@ valueToCode block name ordr =
     case unpack $ js_valueToCode block (pack name) (order ordr) of
       "" ->  Left block
       val -> Right val
-                -- case getInputBlock block name of
-                --   Just inputBlock -> let val = unpack $ js_valueToCode block (pack name) (order ordr)
-                --                      in if val=="" 
-                --                         then Left block
-                --                         else Right val 
-                --   Nothing -> Left block
 
 --- FFI
 foreign import javascript unsafe "Blockly.FunBlocks[$1] = $2"
@@ -625,7 +620,7 @@ foreign import javascript unsafe "Blockly.FunBlocks.valueToCode($1, $2, $3)"
 foreign import javascript unsafe "[$1,$2]"
   js_makeArray :: JSString -> Int -> JSVal
 
-foreign import javascript unsafe "setTimeout(removeErrors,2000)"
+foreign import javascript unsafe "setTimeout(removeErrors,5000)"
   js_removeErrorsDelay :: IO ()
 
 -- TODO, remove, was used for testing

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -476,9 +476,14 @@ blockRGBA block = do
 
 blockLetVar :: GeneratorFunction
 blockLetVar block = do 
-    let varName = getFieldValue block "VARNAME" 
-    expr <- valueToCode block "VARVALUE" CNone
+    let varName = getFieldValue block "NAME" 
+    expr <- valueToCode block "RETURN" CNone
     return $ none $ varName ++ " = " ++ expr 
+
+blockLetCall :: GeneratorFunction
+blockLetCall block = do 
+    let varName = getFieldValue block "NAME" 
+    return $ none varName 
 
 blockComment :: GeneratorFunction
 blockComment block = return $ none ""
@@ -575,7 +580,9 @@ blockCodeMap = [ ("cwBlank",blockBlank)
                   ,("conOdd",blockOdd)
                   ,("conStartWith",blockStartWith)
                   ,("conEndWith",blockEndWith)
-                  ,("letVar",blockLetVar)
+                  -- PROGRAMS
+                  ,("procedures_letVar",blockLetVar)
+                  ,("procedures_callreturn",blockLetCall)
                   ,("comment",blockComment)
                     ]
                                 

--- a/funblocks-client/src/Blocks/Types.hs
+++ b/funblocks-client/src/Blocks/Types.hs
@@ -613,7 +613,7 @@ comment = DesignBlock "comment"
             [TextInput "" "TEXT",
             TextE "--"]
           ]
-          inlineDef (Color 281) typeNone
+          inlineDef (Color 260) typeNone
           (Tooltip "Enter a comment")
 
 getTypeBlocks :: [String]

--- a/funblocks-client/src/Blocks/Types.hs
+++ b/funblocks-client/src/Blocks/Types.hs
@@ -611,7 +611,7 @@ conEndWith = DesignBlock "conEndWith"
 comment = DesignBlock "comment" 
           [Dummy 
             [TextInput "" "TEXT",
-            TextE "Comment"]
+            TextE "--"]
           ]
           inlineDef (Color 281) typeNone
           (Tooltip "Enter a comment")

--- a/funblocks-client/src/Blocks/Types.hs
+++ b/funblocks-client/src/Blocks/Types.hs
@@ -711,7 +711,6 @@ blockTypes = [
               ,conOdd
               ,conStartWith
               ,conEndWith
-              ,letVar
               ,comment
                 ]
 

--- a/funblocks-client/src/Blocks/Types.hs
+++ b/funblocks-client/src/Blocks/Types.hs
@@ -643,7 +643,7 @@ blockTypes = [
               ,cwRotate
               ,cwScale
               -- NUMBERS
-              ,numNumber
+              --,numNumber
               ,numAdd
               ,numSub
               ,numMult

--- a/funblocks-client/src/Main.hs
+++ b/funblocks-client/src/Main.hs
@@ -37,7 +37,7 @@ import Blocks.CodeGen
 import Blocks.Types
 import Blockly.Event
 import Blockly.General
-import Blockly.Block (getBlockType, getOutputBlock, getColour, setColour)
+import Blockly.Block 
 
 -- call blockworld.js compile
 foreign import javascript unsafe "compile($1)"
@@ -81,7 +81,18 @@ main = do
       on btnRun click (btnRunClick workspace)
       liftIO setBlockTypes -- assign layout and types of Blockly blocks
       -- liftIO $ addChangeListener workspace (onVarConnect workspace)
+      liftIO $ addChangeListener workspace (onGeneral workspace)
       return ()
+
+onGeneral workspace event = case getType event of
+      MoveEvent e -> do
+        let uuid = getBlockId e
+        case getBlockById workspace uuid of
+          Just block -> case (getOutputConnection block, isTopBlock workspace block) of
+                          (Just _, True) -> setDisabled block True
+                          _ -> setDisabled block False
+          Nothing -> return ()
+      _ -> return ()
 
 -- change the color of a var block 
 onVarConnect workspace event = do

--- a/funblocks-client/src/Main.hs
+++ b/funblocks-client/src/Main.hs
@@ -89,8 +89,8 @@ onGeneral workspace event = case getType event of
         let uuid = getBlockId e
         case getBlockById workspace uuid of
           Just block -> case (getOutputConnection block, isTopBlock workspace block) of
-                          (Just _, True) -> setDisabled block True
-                          _ -> setDisabled block False
+                            (Just _, True) -> setDisabled block True
+                            _ -> setDisabled block False
           Nothing -> return ()
       _ -> return ()
 

--- a/web/blocks.html
+++ b/web/blocks.html
@@ -12,9 +12,10 @@
     integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7"
     crossorigin="anonymous">
     
-    <!-- Optional bootstrap theme -->
+    <!-- CSS -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/blockly.css">
+    <link rel="stylesheet" href="css/funblocks.css">
     <link rel="stylesheet" href="css/codemirror.css">
     <link rel="stylesheet" href="css/codeworld-cm.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.0/sweetalert.min.css">

--- a/web/blocks.html
+++ b/web/blocks.html
@@ -175,8 +175,7 @@
                           <block type="conStartWith"></block>
                           <block type="conEndWith"></block>
                       </category>
-                      <category name="Definitions">
-                          <block type="letVar"></block>
+                      <category name="Definitions" custom="PROCEDURE">
                       </category>
                       
                    </xml>

--- a/web/css/blockly.css
+++ b/web/css/blockly.css
@@ -78,6 +78,8 @@
   stroke-width: 3px;
 }
 .blocklyErrorSelected>.blocklyPath {
+  stroke-width: 3px;
+  stroke: red;
   fill: maroon;
   opacity: 0.8;
 }

--- a/web/css/blockly.css
+++ b/web/css/blockly.css
@@ -78,9 +78,8 @@
   stroke-width: 3px;
 }
 .blocklyErrorSelected>.blocklyPath {
-  stroke: #fc3;
+  fill: maroon;
   opacity: 0.8;
-  stroke-width: 4px;
 }
 .blocklyErrorSelected>.blocklyPathLight {
   display: none;
@@ -487,26 +486,3 @@
   padding: 0;
 }
 
-/* TODO Maybe move to seperate file or rename to funblocks.css */
-#sidebar {
-  transition: margin 0.3s ease;
-}
-
-.collapsed {
-  display: none;
-}
-
-@media (min-width: 992px) {
-  .collapsed {
-    display: block;
-    margin-left: -25%;
-  }
-}
-
-#row-main {
-    overflow-x: hidden;
-}
-
-#main {
-    transition: width 0.3s ease;
-}

--- a/web/css/funblocks.css
+++ b/web/css/funblocks.css
@@ -1,0 +1,22 @@
+#sidebar {
+  transition: margin 0.3s ease;
+}
+
+.collapsed {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .collapsed {
+    display: block;
+    margin-left: -25%;
+  }
+}
+
+#row-main {
+    overflow-x: hidden;
+}
+
+#main {
+    transition: width 0.3s ease;
+}

--- a/web/js/blockworld.js
+++ b/web/js/blockworld.js
@@ -538,7 +538,6 @@ function discoverProjects() {
 
     var data = new FormData();
     data.append('id_token', auth2.currentUser.get().getAuthResponse().id_token);
-    // TODO change buildMode here to blocklyXML
     data.append('mode', 'blocklyXML');
 
     sendHttp('POST', 'listProjects', data, function(request) {
@@ -567,9 +566,10 @@ function loadProject(name) {
         if (request.status == 200) {
             var project = JSON.parse(request.responseText);
             openProjectName = name;
+
+            clearRunCode();
             loadWorkspace(project.source);
             updateUI();
-            //setCode(project.source, project.history, name);
         }
     });
 
@@ -708,10 +708,19 @@ function deleteProject() {
 }
 
 function newProject() {
+    clearRunCode();
     clearWorkspace();
     openProjectName = null;
     discoverProjects();
     updateUI();
+}
+
+// Clear the running iframe and generated code
+function clearRunCode()
+{
+    var runner = document.getElementById('runner');
+    runner.contentWindow.location.replace('about:blank');
+    updateEditor('');
 }
 
 function clearWorkspace()

--- a/web/js/blockworld.js
+++ b/web/js/blockworld.js
@@ -55,6 +55,7 @@ function loadWorkspace(text)
   workspace.clear();
   var xmldom = Blockly.Xml.textToDom(text);
   Blockly.Xml.domToWorkspace(workspace, xmldom);
+  lastXML = text;
 }
 
 function loadXmlHash(hash)
@@ -68,9 +69,11 @@ function loadXmlHash(hash)
 
 codeworldKeywords = {};
 openProjectName = '';
+lastXML = '';
 function init()
 {
     allProjectNames = [];
+    lastXML = null;
 
     var hash = location.hash.slice(1);
     if (hash.length > 0) {
@@ -346,6 +349,30 @@ function getWorkspaceXMLText()
     return xml_text;
 }
 
+function containsUnsavedChanges()
+{
+  if(!lastXML)
+    return false;
+  return getWorkspaceXMLText() != lastXML;
+}
+
+function warnIfUnsaved(action) {
+    if (!containsUnsavedChanges()) {
+        action();
+    } else {
+        var msg = 'There are unsaved changes to your project. ' + 'Continue and throw away your changes?';
+        sweetAlert({
+            title: 'Warning',
+            text: msg,
+            type: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#DD6B55',
+            confirmButtonText: 'Yes, discard my changes!'
+        }, action);
+    }
+}
+
+
 function compile(src) {
     run('', '', 'Building...', false);
 
@@ -372,6 +399,8 @@ function compile(src) {
             var data = new FormData();
             data.append('hash', codeHash);
             data.append('mode', window.buildMode);
+
+            lastXML = xml_text;
 
             sendHttp('POST', 'runMsg', data, function(request) {
                 var msg = '';
@@ -551,6 +580,8 @@ function discoverProjects() {
 }
 
 function loadProject(name) {
+    
+  warnIfUnsaved(function(){
     if (!signedIn()) {
         sweetAlert('Oops!', 'You must sign in to open projects.', 'error');
         updateUI();
@@ -572,7 +603,7 @@ function loadProject(name) {
             updateUI();
         }
     });
-
+  });
 }
 
 function saveProject() {
@@ -587,6 +618,7 @@ function saveProject() {
     } else {
         saveProjectAs();
     }
+
 }
 
 function saveProjectAs() {
@@ -633,6 +665,8 @@ function saveProjectBase(projectName) {
             'source': getWorkspaceXMLText(),
             'history': ''
         };
+
+        lastXML = getWorkspaceXMLText();
 
         var data = new FormData();
         data.append('id_token', auth2.currentUser.get().getAuthResponse().id_token);
@@ -708,11 +742,15 @@ function deleteProject() {
 }
 
 function newProject() {
+  warnIfUnsaved(function()
+  {
     clearRunCode();
     clearWorkspace();
     openProjectName = null;
     discoverProjects();
     updateUI();
+    lastXML = getWorkspaceXMLText();
+  });
 }
 
 // Clear the running iframe and generated code

--- a/web/js/blockworld.js
+++ b/web/js/blockworld.js
@@ -334,6 +334,7 @@ function removeErrors()
 
     blocks.forEach(function(block){
       block.removeErrorSelect();
+      // block.setWarningText(null);
     });
 }
 

--- a/web/js/blockworld.js
+++ b/web/js/blockworld.js
@@ -334,7 +334,7 @@ function removeErrors()
 
     blocks.forEach(function(block){
       block.removeErrorSelect();
-      // block.setWarningText(null);
+      block.setWarningText(null);
     });
 }
 


### PR DESCRIPTION
Let blocks added. When a let definition block is added to the canvas a corresponding call block gets added to the toolbox.
Minor bug: The correct type of the block gets displayed when it is dragged to the canvas, however in the toolbox it is always displayed with a polymorphic connector.

The following issues were fixed:

1. Validation for number block - Issue #176 
2. Escaping for text block - Issue #175 
3. Non entry point, stray blocks get disabled - Issue #173 
4. Run window and code get cleared on project load - Issue #171 
5. Warning is shown when there are unsaved changes that could be lost - Issue #170 
6. Improved visual indication for disconnected inputs: Only single block gets highlighted with a warning popup indicating that the block contains disconnected inputs. The block gets filled maroon with a red highlight. - Issue #169 
7. Let blocks - Issue #148 
8. Early detection of incomplete expressions, issue #145 can now be closed due to the above fixes.
9. Users can only add a singe entry point block - Issue #144 
10. Block editor no longer dies due to running out of type variables - Issue #174.

The comment block text was changed to '--' as well.

Blockly zoom was enabled. This makes it a bit easier to navigate large programs.
