### PR TITLE
Fixed let blocks, added percentage block, warn when leaving page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 *.jsexe
 *.swp
 nohup.out
+web/closure-library
+third_party/closure-library

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -164,6 +164,12 @@ blockNumber block = do
     let arg = getFieldValue block "NUMBER"
     return $ none arg 
 
+blockNumberPerc :: GeneratorFunction
+blockNumberPerc block = do 
+    let arg = getFieldValue block "NUMBER"
+    let numb = (read arg :: Float) * 0.01
+    return $ none (show numb)
+
 blockAdd :: GeneratorFunction
 blockAdd block = do 
     left <- valueToCode block "LEFT" CAddition
@@ -475,7 +481,7 @@ blockRGBA block = do
     blue <- valueToCode block "BLUE" CNone
     green <- valueToCode block "GREEN" CNone
     alpha <- valueToCode block "ALPHA" CNone
-    return $ none $ "rgba(" ++ red ++ "," ++ blue ++ "," ++ green ++ "," ++ alpha ++ ")" 
+    return $ none $ "RGBA(" ++ red ++ "," ++ green ++ "," ++ blue ++ "," ++ alpha ++ ")" 
 
 blockLetVar :: GeneratorFunction
 blockLetVar block = do 
@@ -516,6 +522,7 @@ blockCodeMap = [ ("cwBlank",blockBlank)
                   ,("cwScale",blockScale)
                   -- NUMBERS
                   ,("numNumber",blockNumber)
+                  ,("numNumberPerc",blockNumberPerc)
                   ,("numAdd",blockAdd)
                   ,("numSub",blockSub)
                   ,("numMult",blockMult)

--- a/funblocks-client/src/Blocks/Types.hs
+++ b/funblocks-client/src/Blocks/Types.hs
@@ -166,8 +166,8 @@ cwTranslate = DesignBlock "cwTranslate"
 cwScale = DesignBlock "cwScale"
           [Dummy [TextE "Scaled"] 
            ,Value "PICTURE" [Text "Picture"] typePicture 
-           ,Value "HORZ" [Text "horizontal"] typeNumber
-           ,Value "VERTZ" [Text "vertical"] typeNumber
+           ,Value "HORZ" [Text "Horizontal"] typeNumber
+           ,Value "VERTZ" [Text "Vertical"] typeNumber
           ] 
           inlineDef colorPicture typePicture 
           (Tooltip "Scale a picture")
@@ -175,7 +175,7 @@ cwScale = DesignBlock "cwScale"
 cwRotate = DesignBlock "cwRotate"
           [Dummy [TextE "Rotated"] 
            ,Value "PICTURE" [Text "Picture"] typePicture 
-           ,Value "ANGLE" [Text "angle"] typeNumber
+           ,Value "ANGLE" [Text "Angle"] typeNumber
           ] 
           inlineDef colorPicture typePicture 
           (Tooltip "Rotate")
@@ -494,8 +494,8 @@ cwTranslucent = DesignBlock "cwTranslucent"
 cwRGBA = DesignBlock "cwRGBA"
           [Dummy [TextE "RGBA"] 
            ,Value "RED"  [Text "Red"] typeNumber 
-           ,Value "BLUE"  [Text "Blue"] typeNumber 
            ,Value "GREEN"  [Text "Green"] typeNumber 
+           ,Value "BLUE"  [Text "Blue"] typeNumber 
            ,Value "ALPHA"  [Text "Alpha"] typeNumber] 
           inlineDef colorColor typeColor 
           (Tooltip "Makes a color with the given red, blue, green and alpha values")

--- a/web/blocks.html
+++ b/web/blocks.html
@@ -267,19 +267,20 @@
                               <shadow type="cwBlank"></shadow>
                             </value>
                             <value name="HORZ">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">1</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">100</field>
                               </shadow>
                             </value>
                             <value name="VERTZ">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">1</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">100</field>
                               </shadow>
                             </value>
                           </block>
                       </category>
                       <category name="Numbers">
                           <block type="numNumber"></block>
+                          <block type="numNumberPerc"></block>
                           <block type="numAdd">
                             <value name="LEFT">
                               <shadow type="numNumber"></shadow>
@@ -442,8 +443,8 @@
                           <block type="cwPurple"></block>
                           <block type="cwGray">
                             <value name="NUM">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">0.5</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">50</field>
                               </shadow>
                             </value>
                           </block>
@@ -482,23 +483,23 @@
                           </block>
                           <block type="cwRGBA">
                             <value name="RED">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">0.5</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">50</field>
                               </shadow>
                             </value>
                             <value name="BLUE">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">0.5</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">50</field>
                               </shadow>
                             </value>
                             <value name="GREEN">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">0.5</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">50</field>
                               </shadow>
                             </value>
                             <value name="ALPHA">
-                              <shadow type="numNumber">
-                                <field name="NUMBER">1</field>
+                              <shadow type="numNumberPerc">
+                                <field name="NUMBER">100</field>
                               </shadow>
                             </value>
                           </block>

--- a/web/js/blockworld.js
+++ b/web/js/blockworld.js
@@ -270,8 +270,13 @@ function init()
         CodeMirror.registerHelper('hintWords', 'codeworld', hints);
     });
 
-
-
+    window.onbeforeunload = function(event) {
+        if (containsUnsavedChanges()) {
+            var msg = 'There are unsaved changes to your project. ' + 'If you continue, they will be lost!';
+            if (event) event.returnValue = msg;
+            return msg;
+        }
+    }
 
 }
 
@@ -351,8 +356,17 @@ function getWorkspaceXMLText()
 
 function containsUnsavedChanges()
 {
+  var blank = '<xml xmlns="http://www.w3.org/1999/xhtml"></xml>';
+  // Initialize if empty
   if(!lastXML)
-    return false;
+  {
+    lastXML = getWorkspaceXMLText();
+    if(lastXML == blank)
+      return false;
+    else
+      return true;
+  }
+
   return getWorkspaceXMLText() != lastXML;
 }
 
@@ -445,8 +459,6 @@ function updateUI()
         document.getElementById('saveAsButton').style.display = 'none';
     }
 
-
-  console.log(showingResult);
   if (window.showingResult) {
         // document.getElementById('result').style.display = '';
         


### PR DESCRIPTION
FunBlocks now warns the user when he tries to leave the page if there are unsaved changes, as per issue #170 

Updated Blockly to handle let variable connecting and disconnecting better. 
The type of all child blocks change when the definition type changes. Child blocks also bump away if there is a type mismatch.
The type changes to polymorphic upon disconnect.
This fixes issue #186. Issue #185 is also fixed, though no additional recursion checking is done.

Added a percentage block. RGBA, Gray and Scaled also now use this percentage block as shadow blocks in the toolbox. This is work for issue #190.
The RGBA block was also fixed.