### PR TITLE
FunBlocks update - minor fixes

### DIFF
--- a/funblocks-client/src/Blockly/Workspace.hs
+++ b/funblocks-client/src/Blockly/Workspace.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE JavaScriptFFI #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 {-
   Copyright 2016 The CodeWorld Authors. All Rights Reserved.
@@ -22,7 +23,9 @@ module Blockly.Workspace ( Workspace(..)
                           ,workspaceToCode
                           ,isTopBlock
                           ,getById
+                          ,getTopBlocksLength
                           ,getBlockById
+                          ,getTopBlocks
                           )
   where
 
@@ -32,7 +35,8 @@ import GHCJS.Foreign
 import GHCJS.Marshal
 import Unsafe.Coerce
 import Blockly.General
-import Blockly.Block (Block)
+import Blockly.Block (Block(..))
+import qualified JavaScript.Array as JA
 
 newtype Workspace = Workspace JSVal
 
@@ -62,6 +66,14 @@ getBlockById workspace (UUID uuidstr) = if isNull val then Nothing
 isTopBlock :: Workspace -> Block -> Bool
 isTopBlock = js_isTopBlock
 
+getTopBlocksLength :: Workspace -> Int
+getTopBlocksLength = js_getTopBlocksLength
+
+getTopBlocks :: Workspace -> IO [Block]
+getTopBlocks ws = do
+  vals :: JA.JSArray <- js_getTopBlocks ws
+  let vs = JA.toList vals
+  return $ map Block vs
 --- FFI
 
 -- TODO Maybe use a list of properties ?
@@ -79,4 +91,10 @@ foreign import javascript unsafe "Blockly.Workspace.getById($1)"
 
 foreign import javascript unsafe "$1.getBlockById($2)"
   js_getBlockById :: Workspace -> JSString -> JSVal
+
+foreign import javascript unsafe "$1.getTopBlocks(false).length"
+  js_getTopBlocksLength :: Workspace -> Int
+
+foreign import javascript unsafe "$1.getTopBlocks(false)"
+  js_getTopBlocks :: Workspace -> IO JA.JSArray
 

--- a/funblocks-client/src/Main.hs
+++ b/funblocks-client/src/Main.hs
@@ -86,12 +86,17 @@ main = do
       liftIO $ addChangeListener workspace (onGeneral workspace)
       return ()
 
+-- Disable blocks that are not top level
 onGeneral workspace event = case getType event of
-      MoveEvent e -> do
+      MoveEvent e ->  disableForEvent e
+      CreateEvent e -> disableForEvent e
+      _ -> return ()
+  where
+    disableForEvent e = do
         let uuid = getBlockId e
         case getBlockById workspace uuid of
           Just block -> case (getOutputConnection block, isTopBlock workspace block) of
                             (Just _, True) -> setDisabled block True
                             _ -> setDisabled block False
           Nothing -> return ()
-      _ -> return ()
+

--- a/funblocks-client/src/Main.hs
+++ b/funblocks-client/src/Main.hs
@@ -60,16 +60,24 @@ setErrorMessage msg = do
   Just msgEl <- getElementById doc "message"
   setInnerHTML msgEl $ Just msg
 
+programBlocks = ["cwDrawingOf"]
+
 btnRunClick ws = do
   Just doc <- liftIO currentDocument
-  code <- liftIO $ workspaceToCode ws
-  case code of
-    "" -> setErrorMessage "Error: Disconnected Inputs"
-    _ -> do
-          liftIO $ js_updateEditor (pack code)
-          liftIO $ js_cwcompile (pack code)
-          -- liftIO js_cwrun
+  blocks <- liftIO $ getTopBlocks ws
+  if not $ containsProgramBlock blocks 
+    then setErrorMessage "Error: No Program on Workspace"
+    else do
+      code <- liftIO $ workspaceToCode ws
+      case code of
+        "" -> setErrorMessage "Error: Disconnected Inputs"
+        _ -> do
+              liftIO $ js_updateEditor (pack code)
+              liftIO $ js_cwcompile (pack code)
+              -- liftIO js_cwrun
   return ()
+  where
+    containsProgramBlock = any (\b -> getBlockType b `elem` programBlocks) 
 
 -- test whether all blocks have codegen
 allCodeGen = filter (`notElem` getGenerationBlocks) getTypeBlocks 


### PR DESCRIPTION
Disable disconnected blocks upon creation event as well - Issue #205

Blockly is updated. Call blocks can't be created from the context menu anymore - Issue #205 . I also think it is better this way, as they are automatically disabled anyway. 

a.getProcedure is correctly called now - Issue #203. Block type changing for the Let definition is still a problem and unchanged.

They can still be created from the toolbar and copying, pasting works now as well.

Added an error message if there are no top level program blocks. This improves point 3. in issue #169 