### PR TITLE
Fix #215: Install from 0.2 branch of ghcjs-dom

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -169,7 +169,7 @@ run . ghcjs-boot --no-prof --no-haddock
 
 # Install ghcjs-dom from hackage.
 
-run $BUILD  git clone https://github.com/ghcjs/ghcjs-dom
+run $BUILD  git clone --branch 0.2 --single-branch https://github.com/ghcjs/ghcjs-dom
 run $BUILD  cabal_install --ghcjs  ./ghcjs-dom
 run $BUILD  rm -rf ghcjs-dom
 


### PR DESCRIPTION
Fix #215: Install from 0.2 branch of ghcjs-dom

Corresponds to versions of ghcjs-dom before package was split into four separate subpackages