### PR TITLE
Stand alone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ of Haskell.  It includes:
 - A simple mathematical model of computer games, inspired by gloss.
 - The ability for students to run and use their creations right in a web
   browser using GHCJS as a compiler.
+- The ability to run the same programs locally, using regular GHC, but still
+  accessing the result via the browser (on <http://localhost:3000/>).
+  This requires only the codeworld-api package (built with -f-ghcjs).
 
 Status
 ======

--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -12,6 +12,11 @@ Description:
   This module provides the drawing code for CodeWorld.  It is heavily inspired by
   Gloss, but modified for consistency and pedagogical reasons and implemented via
   GHCJS for the web.
+  .
+  It comes with two backends. With the ghcjs flag on, it uses GHCJS. This is
+  want runs on <http://code.world/>. With the ghcjs flag off, it uses the blank-canvas
+  package to provide a webpage consisting of just a panel locally. This way, the same
+  program that runs in the CodeWorld API can also be run locally.
 
 Flag ghcjs
     Description: Tell cabal we are using ghcjs (work around until hackage supports impl(ghcjs))

--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -25,11 +25,15 @@ Library
                        CodeWorld.Event,
                        CodeWorld.Driver
   Build-depends:       base,
-                       ghcjs-base,
-                       ghcjs-dom,
                        mtl,
                        random,
                        text,
                        time
+  if flag(ghcjs)
+    Build-depends:
+                       ghcjs-base,
+                       ghcjs-dom
+  else
+    Build-depends:     blank-canvas
   Exposed:             True
   Ghc-options:         -O2

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -43,6 +43,7 @@ import           Control.Monad.Trans (liftIO)
 import           CodeWorld.Color
 import           Data.Monoid
 import           Data.List (zip4)
+import           Numeric
 
 #ifdef ghcjs_HOST_OS
 
@@ -65,7 +66,6 @@ import           GHCJS.Types
 import           JavaScript.Web.AnimationFrame
 import qualified JavaScript.Web.Canvas as Canvas
 import qualified JavaScript.Web.Canvas.Internal as Canvas
-import           Numeric
 import           System.IO.Unsafe
 import           System.Random
 
@@ -536,6 +536,8 @@ interactionOf initial step event draw = go `catch` reportError
 
 --------------------------------------------------------------------------------
 
+#endif
+
 data Wrapped a = Wrapped {
     state          :: a,
     paused         :: Bool,
@@ -682,7 +684,7 @@ simulationOf simInitial simStep simDraw =
             mouseMovedTime = 1000
         }
 
-#else
+#ifndef  ghcjs_HOST_OS
 
 trace :: Text -> a -> a
 trace = undefined
@@ -847,14 +849,6 @@ display pic = Canvas.blankCanvas 3000 $ \context -> do
         setupScreenContext rect
         drawFrame pic
 
-animationOf :: (Double -> Picture) -> IO ()
-animationOf pic = putStrLn "<<animation>>"
-
-simulationOf :: world
-             -> (Double -> world -> world)
-             -> (world -> Picture)
-             -> IO ()
-simulationOf _ _ _ = putStrLn "<<simulation>>"
 
 interactionOf :: world
               -> (Double -> world -> world)


### PR DESCRIPTION
The stand-alone mode now works, including animation and interaction. There might be rough edges, but in principle I think it can be merged. Or at least be tested and reviewed.

I did not change the default assignment of the `ghcjs` flag, but it probably should: Whoever runs `cabal install codeworld-api` probably wants the stand-alone version, and the other version is probably always built by the `build.sh` script, which is a convenient place to specify `-fghcjs`.