### PR TITLE
FunBlocks Update - Hindley Milner and saving loading

### DIFF
--- a/funblocks-client/src/Blockly/Workspace.hs
+++ b/funblocks-client/src/Blockly/Workspace.hs
@@ -28,6 +28,7 @@ module Blockly.Workspace ( Workspace(..)
                           ,getBlockById
                           ,getTopBlocks
                           ,getTopBlocksTrue
+                          ,isWarning
                           ,disableOrphans
                           ,mainWorkspace
                           )
@@ -38,9 +39,11 @@ import Data.JSString (pack, unpack)
 import GHCJS.Foreign
 import GHCJS.Marshal
 import Unsafe.Coerce
+import qualified Data.Text as T
 import Blockly.General
 import Blockly.Block (Block(..))
 import qualified JavaScript.Array as JA
+import Data.JSString.Text 
 
 newtype Workspace = Workspace JSVal
 
@@ -69,6 +72,9 @@ getBlockById workspace (UUID uuidstr) = if isNull val then Nothing
 
 isTopBlock :: Workspace -> Block -> Bool
 isTopBlock = js_isTopBlock
+
+isWarning :: Workspace -> T.Text
+isWarning = textFromJSString . js_isWarning
 
 getTopBlocksLength :: Workspace -> Int
 getTopBlocksLength = js_getTopBlocksLength
@@ -106,6 +112,9 @@ foreign import javascript unsafe "Blockly.FunBlocks.workspaceToCode($1)"
 
 foreign import javascript unsafe "$1.isTopBlock($2)"
   js_isTopBlock :: Workspace -> Block -> Bool 
+
+foreign import javascript unsafe "$1.isWarning()"
+  js_isWarning :: Workspace -> JSString 
 
 foreign import javascript unsafe "Blockly.Workspace.getById($1)"
   js_getById :: JSString -> Workspace

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -152,9 +152,9 @@ instance Pretty Expr where
                           PR.intercalation "," exprs pretty
                           PR.write_ ")"
   pretty (ListCreate exprs) = do 
-                          PR.write_ "("
+                          PR.write_ "["
                           PR.intercalation "," exprs pretty
-                          PR.write_ ")"
+                          PR.write_ "]"
   pretty (ListSpec left right) = do 
                           PR.write_ "["
                           pretty left

--- a/funblocks-client/src/Main.hs
+++ b/funblocks-client/src/Main.hs
@@ -60,23 +60,27 @@ btnStopClick = do
 btnRunClick ws = do
   Just doc <- liftIO currentDocument
   blocks <- liftIO $ getTopBlocks ws
-  if not $ containsProgramBlock blocks 
-    then do 
-      setErrorMessage "No Program block on the workspace"
-    else do
-      (code,errors) <- liftIO $ workspaceToCode ws
-      case errors of
-        ((Error msg block):es) -> do 
-                                    liftIO $ putStrLn $ T.unpack msg
-                                    liftIO $ setWarningText block msg
-                                    liftIO $ addErrorSelect block
-                                    liftIO $ js_removeErrorsDelay
-                                    setErrorMessage (T.unpack msg)
+  let w = isWarning ws
+  if T.length w > 0 then
+    setErrorMessage "A block on the workspace has arguments with the same name"
+  else do
+    if not $ containsProgramBlock blocks 
+      then do 
+        setErrorMessage "No Program block on the workspace"
+      else do
+        (code,errors) <- liftIO $ workspaceToCode ws
+        case errors of
+          ((Error msg block):es) -> do 
+                                      liftIO $ putStrLn $ T.unpack msg
+                                      liftIO $ setWarningText block msg
+                                      liftIO $ addErrorSelect block
+                                      liftIO $ js_removeErrorsDelay
+                                      setErrorMessage (T.unpack msg)
 
-        [] -> do
-          liftIO $ js_updateEditor (pack code)
-          liftIO $ js_cwcompile (pack code)
-  return ()
+          [] -> do
+            liftIO $ js_updateEditor (pack code)
+            liftIO $ js_cwcompile (pack code)
+    return ()
   where
     containsProgramBlock = any (\b -> getBlockType b `elem` programBlocks) 
 

--- a/web/js/blocks/cw-event.js
+++ b/web/js/blocks/cw-event.js
@@ -24,17 +24,34 @@ Blockly.cwEvent = function(){};
 Blockly.cwEvent.generateEventBuiltins = function(xmlList){
 
   var LeftButton = new Blockly.UserTypes.Product("LeftButton",[]);
+  Blockly.TypeInf.addUserDefinedConstructor("LeftButton", Type.fromList( [Type.Lit("MouseButton")]  ) );
+
   var RightButton = new Blockly.UserTypes.Product("RightButton",[]);
+  Blockly.TypeInf.addUserDefinedConstructor("RightButton", Type.fromList( [Type.Lit("MouseButton")]  ) );
+
   var MiddleButton = new Blockly.UserTypes.Product("MiddleButton",[]);
+  Blockly.TypeInf.addUserDefinedConstructor("MiddleButton", Type.fromList( [Type.Lit("MouseButton")]  ) );
+
   var MouseButton = new Blockly.UserTypes.Sum("MouseButton", [LeftButton,RightButton,MiddleButton]);
 
 
   var point = Type.Lit("pair",[ Type.Lit("Number"), Type.Lit("Number")]);
+
   var KeyPress = new Blockly.UserTypes.Product("KeyPress", [Type.Lit("Text") ]);
+  Blockly.TypeInf.addUserDefinedConstructor("KeyPress", Type.fromList( [Type.Lit("Text"), Type.Lit("Event") ] ) );
+
   var KeyRelease = new Blockly.UserTypes.Product("KeyRelease", [Type.Lit("Text") ]);
+  Blockly.TypeInf.addUserDefinedConstructor("KeyRelease", Type.fromList( [Type.Lit("Text"), Type.Lit("Event") ] ) );
+
   var MousePress = new Blockly.UserTypes.Product("MousePress", [Type.Lit("MouseButton"), point]);
+  Blockly.TypeInf.addUserDefinedConstructor("MousePress", Type.fromList( [Type.Lit("MouseButton"), point, Type.Lit("Event")] ) );
+
   var MouseRelease = new Blockly.UserTypes.Product("MouseRelease", [ Type.Lit("MouseButton"), point]);
+  Blockly.TypeInf.addUserDefinedConstructor("MouseRelease", Type.fromList(  [ Type.Lit("MouseButton"), point, Type.Lit("Event")] ) );
+
   var MouseMovement = new Blockly.UserTypes.Product("MouseMovement", [point]);
+  Blockly.TypeInf.addUserDefinedConstructor("MouseMovement", Type.fromList(  [point, Type.Lit("Event")] ) );
+
   var Event = new Blockly.UserTypes.Sum("Event",[KeyPress, KeyRelease, MousePress, MouseRelease, MouseMovement]);
 
 

--- a/web/js/blocks/cw-lists.js
+++ b/web/js/blocks/cw-lists.js
@@ -86,9 +86,10 @@ Blockly.Blocks['lists_comprehension'] = {
         exp.tag = inp.connection;
         result = Exp.Let(varName, Exp.App(Exp.Var("<]"),exp) , result); 
       }
+      else{
+        result = Exp.Let(varName, Exp.Var('undef') , result); 
+      }
     }
-    console.log(result.toString());
-    // let i = <] exp1 in ...
    
     result = Exp.App(Exp.Var("MK"), result);
     result.tag = this.outputConnection;
@@ -164,11 +165,14 @@ Blockly.Blocks['lists_comprehension'] = {
 
   getVars: function(connection){
     var i = 0;
+    var available = [];
     for(i = 0; i < this.varCount_; i++){
       if(this.getInput('DO').connection == connection)
         return this.vars_;
+
+      available = available.concat(this.vars_[i]);
       if(this.getInput('VAR' + i).connection == connection)
-        return [this.vars_[i]];
+        return available;
       
     }
     return [];
@@ -482,7 +486,6 @@ Blockly.Blocks['lists_create_with_typed'] = {
     var func = (a,b) => Exp.AppFunc([a,b],Exp.Var(":"));
     var e = this.foldr(func,Exp.Var("[]"),exps);
     e.tag = this.outputConnection;
-    console.log(e.toString());
     return e;
   },
 

--- a/web/js/blocks/cw-pictures.js
+++ b/web/js/blocks/cw-pictures.js
@@ -161,12 +161,11 @@ Blockly.Blocks['lists_path'] = {
     this.setColour(160);
     this.appendValueInput('LST')
         .appendField(new Blockly.FieldLabel("path","blocklyTextEmph") );
-    var pair = Type.Lit("pair", [Type.Lit("Number"), Type.Lit("Number")]);
     this.setOutput(true);
+    var pair = Type.Lit("pair", [Type.Lit("Number"), Type.Lit("Number")]);
     Blockly.TypeInf.defineFunction("path", Type.fromList([Type.Lit("list", [pair]), Type.Lit("Picture")]));
     this.setAsFunction("path");
-  },
-  getExpr: null
+  }
 };
 
 


### PR DESCRIPTION
I'm switching to fully using the Hindley Milner type inference, which is enabled by default in this.
Each expression is tagged with a connection, which is updated afterwards. Unconnected inputs have polymorphic type. 
Each block now also has a lambda expression, for example, the list create block might have the expression 

```
a:(b:(c:[]))
```

Builtin function types are added to the environment, and blocks are function application on them.
For example circle is added to the environment as 

```
circle : Number -> Picture
```

the circle block either applies the connected expression or `forall a. a` if the input is disconnected, which yields something such as

```
(circle)(3)
```

This new behavior is much less adhoc and extending it to new blocks only requires defining the appropriate expression. I think this will turn out better for maintenance as well, the previous unification was all over the place for tricky blocks.
Some things that still need to be done regarding HM:

- Correctly define top level functions for use in other functions and add them to the environment. Currently they are just polymorphic.
- Local variables are currently not tagged and set. 

This also fixes issues surrounding saving/loading. I tested this for most blocks and created a few interactions which save and load fine now. There were various issues causing the breakage.

Other changes:

- Enable/Disable sub expressions properly - Issue #271
- Stop compilation on Blockly warnings - Issue #260 
- User defined functions behave more intuitive now, Issue #270. There is still some room for improvement, such as rendering the parameters on the right side. The reason for switching in the previous PR was to converge to a stable release faster, as rendering them on the left is much easier and better supported in Blockly. But the old rendering can be re-enabled for a future feature.

