### PR TITLE
FunBlocks Update - User data type fixes

### DIFF
--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -143,7 +143,7 @@ instance Pretty Expr where
                                                               PR.writeLine ""
                                                               PR.write con
                                                               PR.makeSpace
-                                                              when (length vars > 1) $ do
+                                                              when (length vars > 0) $ do
                                                                 PR.write_ "("
                                                                 PR.write_ $ T.intercalate "," vars 
                                                                 PR.write_ ")"

--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -73,7 +73,7 @@ instance Pretty Type where
                           PR.write_ "]"
 
 instance Pretty Expr where
-  pretty (LiteralS s) = PR.write_ $ escape s
+  pretty (LiteralS s) = PR.write_ s
   pretty (LiteralN d) = PR.write_ $ if d == fromInteger (truncate d)
                                     then show $ truncate d
                                     else show d
@@ -201,20 +201,6 @@ workspaceToCode workspace = do
         Just func -> let (SE code err) = func block
                      in SE code err
         Nothing -> errc "No such block in CodeGen" block
-
-
--- Helper functions
-
--- Escapes a string
-
-escape :: T.Text -> T.Text
-escape xs = T.pack $ escape' (T.unpack xs)
-escape' :: String -> String
-escape' xs = ("\""::String) P.++ (concatMap f xs :: String ) P.++ ("\""::String) where
-    f :: Char -> String
-    f ('\\'::Char) = "\\\\" :: String
-    f ('\"'::Char) = "\\\"" :: String
-    f x    = [x]
 
 
 

--- a/funblocks-client/src/Blocks/Parser.hs
+++ b/funblocks-client/src/Blocks/Parser.hs
@@ -165,17 +165,27 @@ blockCombine block = do
 
 -- TEXT --------------------------------------------------
 
+-- Escapes a string
+
+escape :: T.Text -> T.Text
+escape xs = T.pack $ escape' (T.unpack xs)
+escape' :: String -> String
+escape' xs = ("\""::String) P.++ (concatMap f xs :: String ) P.++ ("\""::String) where
+    f :: Char -> String
+    f ('\\'::Char) = "\\\\" :: String
+    f ('\"'::Char) = "\\\"" :: String
+    f x    = [x]
+
 blockString :: ParserFunction
 blockString block = do 
     let txt = getFieldValue block "TEXT" 
-    return $ LiteralS txt 
+    return $ LiteralS $ escape txt 
 
 blockConcat :: ParserFunction
 blockConcat block = do
   let c = getItemCount block
   vals <- mapM (\t -> valueToExpr block t) ["STR" ++ show i | i <- [0..c-1]]
   return $ foldr1 (CallFuncInfix "<>") vals
-
 
 -- LOGIC ------------------------------------------
 

--- a/funblocks-client/src/Blocks/Parser.hs
+++ b/funblocks-client/src/Blocks/Parser.hs
@@ -170,11 +170,7 @@ blockCombine block = do
 escape :: T.Text -> T.Text
 escape xs = T.pack $ escape' (T.unpack xs)
 escape' :: String -> String
-escape' xs = ("\""::String) P.++ (concatMap f xs :: String ) P.++ ("\""::String) where
-    f :: Char -> String
-    f ('\\'::Char) = "\\\\" :: String
-    f ('\"'::Char) = "\\\"" :: String
-    f x    = [x]
+escape' = P.show 
 
 blockString :: ParserFunction
 blockString block = do 


### PR DESCRIPTION
This update addresses the following issues:

1. Top case expression now gets inferred - #304
2. Fix bug causing #303 and 
3. Prevent #302 by renaming internal `ev` to `1ev`
4. Fix case codegen #301 and #297 
6. Fix constructor bug - #291

I moved escape to the parsing code, in the event we want to add a block with a character that shouldn't get escaped. (I wanted a newline character but it doesn't get drawn, so i'm not sure if this is actually necessary)