### PR TITLE
Blocks Update - Bug fixes

### DIFF
--- a/funblocks-client/src/Blocks/Types.hs
+++ b/funblocks-client/src/Blocks/Types.hs
@@ -432,7 +432,7 @@ blockTypes = [
               ,cwTranslucent
               ,cwRGBA
               -- LOGIC
-              ,conIf
+              -- ,conIf
               ,conAnd
               ,conOr
               ,conNot

--- a/funblocks-client/src/Main.hs
+++ b/funblocks-client/src/Main.hs
@@ -77,8 +77,18 @@ runOrError ws = do
             liftIO $ js_cwcompile (pack code)
 
 
+-- Update the hash on the workspace
+-- Mainly so that broken programs can be shared
+updateCode :: Workspace -> IO ()
+updateCode ws = do
+        (code,errors) <- workspaceToCode ws
+        liftIO $ js_updateEditor (pack code)
+        liftIO $ js_cwcompilesilent (pack code)
+
+
 btnRunClick ws = do
   Just doc <- liftIO currentDocument
+  liftIO $ updateCode ws
   blocks <- liftIO $ getTopBlocks ws
   (block, w) <- liftIO $ isWarning ws
   if T.length w > 0 then do
@@ -148,6 +158,9 @@ setRunFunc ws = do
 -- call blockworld.js compile
 foreign import javascript unsafe "compile($1)"
   js_cwcompile :: JSString -> IO ()
+
+foreign import javascript unsafe "compile($1,true)"
+  js_cwcompilesilent :: JSString -> IO ()
 
 -- call blockworld.js run
 -- run (xmlHash, codeHash, msg, error)

--- a/web/blocks.html
+++ b/web/blocks.html
@@ -37,7 +37,7 @@
 
     <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
 
-    <script src="blockly/blockly_uncompressed.js"></script>
+    <script src="blockly/blockly_compressed.js"></script>
     <script src="blockly/blocks/lists.js"></script>
     <!-- CodeWorld blocks -->
     <script src="js/blocks/cw-text.js"></script>

--- a/web/blocks.html
+++ b/web/blocks.html
@@ -37,7 +37,7 @@
 
     <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
 
-    <script src="blockly/blockly_compressed.js"></script>
+    <script src="blockly/blockly_uncompressed.js"></script>
     <script src="blockly/blocks/lists.js"></script>
     <!-- CodeWorld blocks -->
     <script src="js/blocks/cw-text.js"></script>

--- a/web/blocks.html
+++ b/web/blocks.html
@@ -41,6 +41,7 @@
     <script src="blockly/blocks/lists.js"></script>
     <!-- CodeWorld blocks -->
     <script src="js/blocks/cw-text.js"></script>
+    <script src="js/blocks/cw-logic.js"></script>
     <script src="js/blocks/cw-tuples.js"></script>
     <script src="js/blocks/cw-pictures.js"></script>
     <script src="js/blocks/cw-math.js"></script>

--- a/web/help/blockframe.html
+++ b/web/help/blockframe.html
@@ -26,6 +26,7 @@
     <script src="../blockly/blocks/lists.js"></script>
     <!-- CodeWorld blocks -->
     <script src="../js/blocks/cw-text.js"></script>
+    <script src="../js/blocks/cw-logic.js"></script>
     <script src="../js/blocks/cw-tuples.js"></script>
     <script src="../js/blocks/cw-pictures.js"></script>
     <script src="../js/blocks/cw-math.js"></script>

--- a/web/js/blocks/cw-logic.js
+++ b/web/js/blocks/cw-logic.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 The CodeWorld Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+goog.provide('Blockly.Blocks.cwLogic');
+goog.require('Blockly.Blocks');
+
+var colorPoly = 180;
+
+Blockly.Blocks['conIf'] = {
+  init: function() {
+    this.setColour(colorPoly);
+    this.appendValueInput('IF')
+        .appendField('if');
+    this.appendValueInput('THEN')
+        .appendField('then');
+    this.appendValueInput('ELSE')
+        .appendField('else');
+    this.setInputsInline(true);
+    this.setOutput(true);
+    Blockly.TypeInf.defineFunction("if", Type.fromList([Type.Lit("Truth"), Type.Var("a"), Type.Var("a"), Type.Var("a")]));
+    this.setAsFunction("if");
+  }
+};

--- a/web/js/blocks/cw-pictures.js
+++ b/web/js/blocks/cw-pictures.js
@@ -123,7 +123,17 @@ Blockly.Blocks['cwCombine'] = {
     tps.push(Type.Lit("Picture"));
     this.arrows = Type.fromList(tps);
     this.initArrows();
-
+  },
+  saveConnections: function(containerBlock) {
+    var itemBlock = containerBlock.getInputTargetBlock('STACK');
+    var x = 0;
+    while (itemBlock) {
+      var input = this.getInput('PIC' + x);
+      itemBlock.valueConnection_ = input && input.connection.targetConnection;
+      x++;
+      itemBlock = itemBlock.nextConnection &&
+          itemBlock.nextConnection.targetBlock();
+    }
   }
 };
 

--- a/web/js/blocks/cw-pictures.js
+++ b/web/js/blocks/cw-pictures.js
@@ -129,6 +129,14 @@ Blockly.Blocks['cwCombine'] = {
     var x = 0;
     while (itemBlock) {
       var input = this.getInput('PIC' + x);
+      if(input && input.connection.targetConnection){
+        if(input.connection.targetBlock().isShadow_){
+          x++;
+          itemBlock = itemBlock.nextConnection &&
+          itemBlock.nextConnection.targetBlock();
+          continue;
+        }
+      }
       itemBlock.valueConnection_ = input && input.connection.targetConnection;
       x++;
       itemBlock = itemBlock.nextConnection &&

--- a/web/js/blocks/cw-text.js
+++ b/web/js/blocks/cw-text.js
@@ -161,6 +161,18 @@ Blockly.Blocks['txtConcat'] = {
     this.arrows = Type.fromList(tps);
     this.initArrows();
   },
+
+  saveConnections: function(containerBlock) {
+    var itemBlock = containerBlock.getInputTargetBlock('STACK');
+    var x = 0;
+    while (itemBlock) {
+      var input = this.getInput('STR' + x);
+      itemBlock.valueConnection_ = input && input.connection.targetConnection;
+      x++;
+      itemBlock = itemBlock.nextConnection &&
+          itemBlock.nextConnection.targetBlock();
+    }
+  }
 };
 
 Blockly.Blocks['text_combine_ele'] = {

--- a/web/js/blocks/cw-text.js
+++ b/web/js/blocks/cw-text.js
@@ -167,6 +167,14 @@ Blockly.Blocks['txtConcat'] = {
     var x = 0;
     while (itemBlock) {
       var input = this.getInput('STR' + x);
+      if(input && input.connection.targetConnection){
+        if(input.connection.targetBlock().isShadow_){
+          x++;
+          itemBlock = itemBlock.nextConnection &&
+          itemBlock.nextConnection.targetBlock();
+          continue;
+        }
+      }
       itemBlock.valueConnection_ = input && input.connection.targetConnection;
       x++;
       itemBlock = itemBlock.nextConnection &&

--- a/web/js/blocks/init.js
+++ b/web/js/blocks/init.js
@@ -28,6 +28,9 @@ goog.require('Blockly.Blocks.cwEvent');
 Blockly.Flyout.programBlockList = ["cwAnimationOf", "cwDrawingOf", "cwSimulationOf","cwInteractionOf" ];
 // Automatically generate a type block for each of these
 Blockly.UserTypes.builtinsStatic = ["Truth", "Number", "Color", "Picture", "Text"];
+
+Blockly.UserTypes.userReservedNames = ['do','let','in','if','then','else','data','type','newtype','import','qualified']
+
 // Add a these blockTypes to the toolbox
 Blockly.UserTypes.builtinsDynamic = ["type_list"];
 // Enable the Event drawer

--- a/web/js/funblocks.js
+++ b/web/js/funblocks.js
@@ -141,15 +141,17 @@ function run(xmlHash, codeHash, msg, error, dhash) {
       document.getElementById('message').style.display = 'none';
     }
 
+    
+    if(msg){
+      var message = document.getElementById('message');
+      message.innerHTML = '';
+      addToMessage(msg);
 
-    var message = document.getElementById('message');
-    message.innerHTML = '';
-    addToMessage(msg);
-
-    if (error) {
-        message.classList.add('error');
-    } else {
-        message.classList.remove('error');
+      if (error) {
+          message.classList.add('error');
+      } else {
+          message.classList.remove('error');
+      }
     }
 
     document.getElementById('editButton').setAttribute('href','/#' + codeHash);
@@ -186,7 +188,7 @@ function isEditorClean()
   return !containsUnsavedChanges();
 }
 
-function compile(src) {
+function compile(src,silent) {
     run('', '', 'Compiling...', false);
 
     var xml_text = getWorkspaceXMLText();
@@ -228,6 +230,7 @@ function compile(src) {
                 } else if (request.status == 404) {
                     msg = "Sorry!  Your program couldn't be run right now.  Please try again.";
                 }
+                if(silent) msg = null;
 
                 if (success) {
                     run(xmlHash, hash, 'Running...\n\n' + msg, false, dhash);


### PR DESCRIPTION
This change set addresses the following issues:

- Picture combine (&) and text concat (<>) don't disconnect their blocks anymore - #329. However they do still lose their shadow arguments (#309).
- Certain words can be reserved - #351. Custom words can be reserved with `Blockly.UserTypes.userReservedNames` in web/js/blocks/init.js. Codeworld functions defined using `defineFunction` are also reserved.
- Collapsed blocks don't show polymorphic indicators anymore, fixing #347.
- A block in the toolbox must now be dragged a certain distance in order to be created - issue #327.
- Programs that contain errors can be shared after they are run - issue #300 


I'm still investigating #337. The effect exists with other blocks as well; the displacement happens to the polymorphic color indicator; however it is the most pronounced with the `if` block.