### PR TITLE
Fix errors caused when text concatenation and picture combine have less than 2 inputs

### DIFF
--- a/funblocks-client/src/Blocks/CodeGen.hs
+++ b/funblocks-client/src/Blocks/CodeGen.hs
@@ -23,7 +23,7 @@ import Blocks.Parser
 import Blockly.Workspace hiding (workspaceToCode)
 import qualified Data.Map as M
 import qualified Data.Text as T
-import Prelude hiding ((++), show)
+import Prelude hiding ((<>), show)
 import qualified Prelude as P
 import Blockly.Block
 import Data.JSString.Text
@@ -31,9 +31,8 @@ import Control.Monad.State.Lazy (get,put)
 import qualified Control.Monad.State.Lazy as S
 import qualified Blocks.Printer as PR
 import Control.Monad
+import Data.Monoid ((<>))
 
-(++) :: T.Text -> T.Text -> T.Text
-a ++ b = a `T.append` b
 pack = textToJSString
 unpack = textFromJSString
 show :: Show a => a -> T.Text
@@ -49,13 +48,13 @@ class Pretty a where
   pretty :: a -> PR.Printer
 
 -- instance Pretty Product where 
---  pretty (Product s tps) = s ++ " " ++ T.concat (map pretty tps)
+--  pretty (Product s tps) = s <> " " <> T.concat (map pretty tps)
 
 instance Pretty Type where
   pretty (Type s) = PR.write_ s
-  pretty (Sum typeName [] ) = PR.write_ $ "data " ++ typeName -- Empty data declaration
+  pretty (Sum typeName [] ) = PR.write_ $ "data " <> typeName -- Empty data declaration
   pretty (Sum typeName (tp:tps) ) = do 
-                                      PR.write_ $ "data " ++ typeName ++ " ="
+                                      PR.write_ $ "data " <> typeName <> " ="
                                       c <- PR.getCol
                                       PR.write_ " "
                                       pretty tp
@@ -115,7 +114,7 @@ instance Pretty Expr where
 
   pretty (FuncDef name vars expr) = do 
                                       let varCode = if not $ null vars 
-                                                    then "(" ++ T.intercalate "," vars ++ ")"
+                                                    then "(" <> T.intercalate "," vars <> ")"
                                                     else ""
                                       PR.write_ name
                                       if null vars then return () else PR.write_ varCode

--- a/funblocks-client/src/Blocks/Parser.hs
+++ b/funblocks-client/src/Blocks/Parser.hs
@@ -161,7 +161,10 @@ blockCombine :: ParserFunction
 blockCombine block = do
   let c = getItemCount block
   vals <- mapM (\t -> valueToExpr block t) ["PIC" ++ show i | i <- [0..c-1]]
-  return $ foldr1 (CallFuncInfix "&") vals
+  return $ case vals of
+            [] -> CallFuncInfix "&" Comment Comment
+            [x] -> CallFuncInfix "&" x Comment
+            _ -> foldr1 (CallFuncInfix "&") vals
 
 
 -- TEXT --------------------------------------------------
@@ -182,7 +185,10 @@ blockConcat :: ParserFunction
 blockConcat block = do
   let c = getItemCount block
   vals <- mapM (\t -> valueToExpr block t) ["STR" ++ show i | i <- [0..c-1]]
-  return $ foldr1 (CallFuncInfix "<>") vals
+  return $ case vals of
+            [] -> CallFuncInfix "<>" Comment Comment
+            [x] -> CallFuncInfix "<>" x Comment
+            _ -> foldr1 (CallFuncInfix "<>") vals
 
 -- LOGIC ------------------------------------------
 

--- a/web/js/blocks/cw-pictures.js
+++ b/web/js/blocks/cw-pictures.js
@@ -52,6 +52,11 @@ Blockly.Blocks['cwCombine'] = {
       else
         exps.push(Exp.Var('undef'));
     });
+    if(exps.length < 2){ // If the block has less than 2 inputs, warn the user
+      exps = [];
+      exps.push(Exp.Var('undef'));
+      exps.push(Exp.Var('undef'));
+    } 
     var func = (a,b) => Exp.AppFunc([a,b],Exp.Var("&"));
     var e = this.foldr1(func,exps);
     return e;
@@ -101,6 +106,13 @@ Blockly.Blocks['cwCombine'] = {
     this.arrows = Type.fromList(tps);
     this.initArrows();
     this.renderMoveConnections_();
+
+    if(this.itemCount_ < 2){
+      this.setWarningText('This block requires at least 2 inputs');
+    }
+    else{
+      this.setWarningText(null)
+    }
   },
 
   mutationToDom: function() {

--- a/web/js/blocks/cw-text.js
+++ b/web/js/blocks/cw-text.js
@@ -87,6 +87,12 @@ Blockly.Blocks['txtConcat'] = {
       else
         exps.push(Exp.Var('undef'));
     });
+    if(exps.length < 2){ // If the block has less than 2 inputs, warn the user
+      exps = [];
+      exps.push(Exp.Var('undef'));
+      exps.push(Exp.Var('undef'));
+    } 
+
     var func = (a,b) => Exp.AppFunc([a,b],Exp.Var("<>"));
     var e = this.foldr1(func,exps);
     return e;
@@ -136,6 +142,13 @@ Blockly.Blocks['txtConcat'] = {
     tps.push(new Type.Lit("Text"));
     this.arrows = Type.fromList(tps);
     this.initArrows();
+
+    if(this.itemCount_ < 2){
+      this.setWarningText('This block requires at least 2 inputs');
+    }
+    else{
+      this.setWarningText(null)
+    }
   },
 
   mutationToDom: function() {


### PR DESCRIPTION
This update addresses issue #370. A warning is also shown when these block have less than two inputs.

Additionally, the updated Blockly shows an `=` sign for the first input when defining a user data type (issue #365).

A minor change is that `<>` is now used for `Text` concatenation in the Parsing and CodeGen code in place of my own `++` that was defined for appending `Text`