### PR TITLE
Add a stress test client for the game server

### DIFF
--- a/codeworld-game-api/src/CodeWorld/Message.hs
+++ b/codeworld-game-api/src/CodeWorld/Message.hs
@@ -88,4 +88,4 @@ data ServerMessage
     | OutEvent Double PlayerId String
     | OutPing Double PlayerId
     | GameAborted
-    deriving (Show, Read)
+    deriving (Show, Read, Eq) -- Eq is only for testing

--- a/codeworld-game-server/codeworld-game-server.cabal
+++ b/codeworld-game-server/codeworld-game-server.cabal
@@ -28,3 +28,17 @@ executable codeworld-game-server
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts "-with-rtsopts=-N"
+
+executable codeworld-game-stresstest
+  main-is:             Stresstest.hs
+  build-depends:       base >=4.8 && <4.9,
+                       bytestring,
+                       text,
+                       websockets == 0.9.*,
+                       codeworld-game-api,
+                       async,
+                       clock,
+                       optparse-applicative
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts "-with-rtsopts=-N"

--- a/codeworld-game-server/src/Stresstest.hs
+++ b/codeworld-game-server/src/Stresstest.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-
+  Copyright 2016 The CodeWorld Authors. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-}
+
+import CodeWorld.Message
+
+import System.Clock
+import Data.List
+import Text.Read
+import Control.Monad
+import qualified Data.Text as T
+import qualified Data.ByteString.Char8 as BS
+import qualified Network.WebSockets as WS
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception
+import Options.Applicative
+
+connect :: Config -> WS.ClientApp a -> IO a
+connect Config {..} = WS.runClient hostname port path
+
+sendClientMessage :: ClientMessage -> WS.Connection ->  IO ()
+sendClientMessage msg conn = WS.sendTextData conn (T.pack (show msg))
+
+
+
+getServerMessage :: WS.Connection -> IO ServerMessage
+getServerMessage conn = do
+    msg <- WS.receiveData conn
+    case readMaybe (T.unpack msg) of
+        Just msg -> return msg
+        Nothing -> fail "Invalid server message"
+
+joinGame :: Config -> GameId -> IO [ServerMessage]
+joinGame config gid = do
+    connect config $ \conn -> do
+        sendClientMessage (JoinGame gid sig) conn
+        JoinedAs _ _ <- getServerMessage conn
+        waitForStart config conn
+
+waitForStart :: Config -> WS.Connection -> IO [ServerMessage]
+waitForStart config conn = go
+  where
+    go = do
+        m <- getServerMessage conn
+        case m of
+            Started {} -> playGame config conn
+            _ -> go
+
+playGame :: Config -> WS.Connection -> IO [ServerMessage]
+playGame config conn = do
+    forkIO $ sendMessages config conn
+    getAllMessages config conn
+
+sendMessages :: Config -> WS.Connection -> IO ()
+sendMessages config conn = do
+    forM_ [1..events config] $ \n -> do
+        sendClientMessage (InEvent 5 (show n)) conn
+
+getAllMessages :: Config -> WS.Connection -> IO [ServerMessage]
+getAllMessages config conn =
+    replicateM (nrequests config) (getServerMessage conn) <*
+    WS.sendClose conn BS.empty
+
+timeSpecToS ts = fromIntegral (sec ts) + fromIntegral (nsec ts) * 1E-9
+
+data Config = Config
+    { clients  :: Int
+    , events   :: Int
+    , hostname :: String
+    , port     :: Int
+    , path     :: String
+    }
+
+opts = info (helper <*> config)
+      ( fullDesc
+     <> progDesc "CodeWorld gameserver stresstest client"
+     <> header "codeword-game-stresstest - a stresstest for codeworld-gameserver")
+  where
+    config :: Parser Config
+    config = Config
+      <$> option auto
+          ( long "clients"
+         <> short 'c'
+         <> showDefault
+         <> metavar "N"
+         <> value 3
+         <> help "Number of clients (>=1)" )
+      <*> option auto
+          ( long "events"
+         <> short 'e'
+         <> showDefault
+         <> metavar "M"
+         <> value 100
+         <> help "Number of events every client should send" )
+      <*> strOption
+          ( long "hostname"
+         <> showDefault
+         <> value "0.0.0.0"
+         <> metavar "HOSTNAME"
+         <> help "Hostname" )
+      <*> option auto
+          ( long "port"
+         <> showDefault
+         <> metavar "PORT"
+         <> value 9160
+         <> help "Port" )
+      <*> strOption
+          ( long "path"
+         <> showDefault
+         <> metavar "PATH"
+         <> value "gameserver"
+         <> help "Path" )
+
+main = do
+  config <- execParser opts
+  start <- getTime Monotonic
+  connect config $ \conn -> do
+    sendClientMessage (NewGame (clients config) sig) conn
+    JoinedAs 0 gid <- getServerMessage conn
+    results <- mapConcurrently id $
+        waitForStart config conn : replicate (clients config - 1) (joinGame config gid)
+    end <- getTime Monotonic
+
+    let consistent = all (== head results) (tail results)
+    if consistent then putStrLn "All clients got consistent data."
+                  else putStrLn "The clients got different results!"
+    putStrLn $ "Events sent:         " ++ show (nrequests config)
+    putStrLn $ "Running time was:    " ++ show (timeSpecToS (end-start) * 1000) ++ "ms"
+    putStrLn $ "Requests per second: " ++ show (fromIntegral (nrequests config) / timeSpecToS (end-start))
+
+sig :: BS.ByteString
+sig = BS.pack "DemoGame"
+
+
+nrequests config = clients config * events config


### PR DESCRIPTION
```
$ ./codeworld-game-stresstest --help
codeword-game-stresstest - a stresstest for codeworld-gameserver

Usage: codeworld-game-stresstest [-c|--clients N] [-e|--events M]
                                 [--hostname HOSTNAME] [--port PORT]
                                 [--path PATH]
  CodeWorld gameserver stresstest client

Available options:
  -h,--help                Show this help text
  -c,--clients N           Number of clients (>=1) (default: 3)
  -e,--events M            Number of events every client should
                           send (default: 100)
  --hostname HOSTNAME      Hostname (default: "0.0.0.0")
  --port PORT              Port (default: 9160)
  --path PATH              Path (default: "gameserver")
$ codeworld-game-stresstest -c 50 -e 1000
All clients got consistent data.
Events sent:         50000
Running time was:    49453.714961000005ms
Requests per second: 1011.0463903355047
```

It will be more fun to replace our read/show based serialization with
something proper if we can measure a real effect here. Also it is good
to know that the broadcasted messages are actually sent and received in
the same order (”consistent data” means that all clients go the same
list of events).