### PR TITLE
Fix #457 Allow Users to Open Help in New Tab

### DIFF
--- a/web/js/doc.js
+++ b/web/js/doc.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+window.env = parent;
 (function() {
     function linkCodeBlocks(linkable=true) {
         codeworldKeywords = {};
@@ -30,8 +31,8 @@
                     if (text.indexOf("main ") != -1 && linkable) {
                         pre.classList.add('clickable');
                         pre.onclick = function() {
-                            if (parent && parent.loadSample) {
-                                parent.loadSample(text);
+                            if (env && env.loadSample) {
+                                env.loadSample(text);
                             }
                         }
                     }
@@ -122,11 +123,32 @@
     request.open('GET', path, true);
     request.onreadystatechange = function() {
         if (request.readyState == 4) {
+          var help = document.getElementById('help');
 
+          var popout = document.createElement('a');
+          popout.innerHTML = '(Open the Help in a New Tab)';
+          popout.target = '_blank';
+          popout.href = document.location.href;
+          popout.onclick = function (e) {
+              var tab = open(this.href);
+              tab.addEventListener("load", function () {
+                  tab.env = parent;
+                  if (parent.sweetAlert) {
+                      parent.sweetAlert.close();
+                  }
+              });
+              e.preventDefault();
+          }
+          if (parent && parent !== window) {
+              help.appendChild(popout);
+          }
+
+          var content = document.createElement('div');
           var text = request.responseText;
           var converter = new Markdown.Converter();
           var html = converter.makeHtml(text);
-          document.getElementById('help').innerHTML = html;
+          content.innerHTML = html;
+          help.appendChild(content);
 
           if(path.includes('blocks')){
             linkFunBlocks();


### PR DESCRIPTION
I heard about your project through the Summer of Haskell site and wanted to help out. Hopefully this small change makes the help a little easier to use.

A link now appears at the top of the help allowing users to open the guide in a new page. Some additional code keeps the pages "linked" so clicking on code samples will still call `loadSample` on the other window.

Another design would have been to put a popout button on the top of the SweetAlert, but I think avoiding a top bar would help save space and keep formatting consistent between browsers. Hopefully I'm not breaking any localization rules by hardcoding the link text.