### PR TITLE
Infinite list of colors

### DIFF
--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -26,15 +26,16 @@ Library
                        CodeWorld.Event,
                        CodeWorld.Driver
                        CodeWorld.CollaborationUI
-  Build-depends:       base                  >= 4.8 && < 5,
-                       containers            >= 0.5.7 && < 0.6,
-                       hashable              >= 1.2.4 && < 1.3,
-                       text                  >= 1.2.2 && < 1.3,
-                       mtl                   >= 2.2.1 && < 2.3,
-                       time                  >= 1.6.0 && < 1.7,
-                       random                >= 1.1 && < 1.2,
-                       cereal                >= 0.5.4 && < 0.6,
-                       cereal-text           >= 0.1.0 && < 0.2
+  Build-depends:       base                 >= 4.8 && < 5,
+                       containers           >= 0.5.7 && < 0.6,
+                       hashable             >= 1.2.4 && < 1.3,
+                       text                 >= 1.2.2 && < 1.3,
+                       mtl                  >= 2.2.1 && < 2.3,
+                       time                 >= 1.6.0 && < 1.7,
+                       random               >= 1.1 && < 1.2,
+                       random-shuffle       >= 0.0.4 && < 0.1,
+                       cereal               >= 0.5.4 && < 0.6,
+                       cereal-text          >= 0.1.0 && < 0.2
 
   if impl(ghcjs)
     Build-depends:

--- a/codeworld-api/src/CodeWorld.hs
+++ b/codeworld-api/src/CodeWorld.hs
@@ -100,7 +100,7 @@ module CodeWorld (
     duller,
     dull,
     translucent,
-    colors,
+    assortedColors,
     hue,
     saturation,
     luminosity,

--- a/codeworld-api/src/CodeWorld.hs
+++ b/codeworld-api/src/CodeWorld.hs
@@ -100,6 +100,7 @@ module CodeWorld (
     duller,
     dull,
     translucent,
+    rainbow,
     hue,
     saturation,
     luminosity,

--- a/codeworld-api/src/CodeWorld.hs
+++ b/codeworld-api/src/CodeWorld.hs
@@ -100,7 +100,7 @@ module CodeWorld (
     duller,
     dull,
     translucent,
-    rainbow,
+    colors,
     hue,
     saturation,
     luminosity,

--- a/codeworld-api/src/CodeWorld/Color.hs
+++ b/codeworld-api/src/CodeWorld/Color.hs
@@ -16,6 +16,8 @@
 
 module CodeWorld.Color where
 
+import Data.Functor (fmap)
+
 data Color = RGBA !Double !Double !Double !Double deriving (Show, Eq)
 type Colour = Color
 
@@ -92,6 +94,18 @@ translucent (RGBA r g b a) = RGBA r g b (a/2)
 gray, grey :: Double -> Color
 gray = grey
 grey k = RGBA k k k 1
+
+-- Produce an infinite list of colors:
+-- https://github.com/google/codeworld/issues/436
+-- The list loops through the HSL spectrum with fixed
+-- saturation and lightness:
+-- https://www.w3schools.com/colors/colors_hsl.asp
+-- A 'speed' parameter allows the user to loop through the colors
+-- in fewer indices.
+rainbow :: Double -> [Color]
+rainbow speed = let
+  coefficients = fmap (\i -> speed * i * pi / 50.0) [0..]
+  in fmap (\h -> fromHSL h 0.75 0.5) coefficients
 
 hue :: Color -> Double
 hue (RGBA r g b a)

--- a/codeworld-api/src/CodeWorld/Color.hs
+++ b/codeworld-api/src/CodeWorld/Color.hs
@@ -16,9 +16,11 @@
 
 module CodeWorld.Color where
 
-import Data.Functor (fmap)
 import Data.List (unfoldr)
 import Data.Fixed (mod')
+
+import System.Random (mkStdGen)
+import System.Random.Shuffle (shuffle')
 
 data Color = RGBA !Double !Double !Double !Double deriving (Show, Eq)
 type Colour = Color
@@ -97,29 +99,17 @@ gray, grey :: Double -> Color
 gray = grey
 grey k = RGBA k k k 1
 
+-- | An infinite list of colors.
 
--- Produce an infinite list of colors:
--- https://github.com/google/codeworld/issues/436
--- The list loops through the HSL spectrum with fixed
--- saturation and lightness:
--- https://www.w3schools.com/colors/colors_hsl.asp
--- http://stackoverflow.com/a/7728626/1007926
+assortedColors :: [Color]
+assortedColors = red : green : blue : more
+  where more = [ fromHSL hue 0.75 0.5
+                 | denom <- doublesOf 6
+                 , numer <- shuffleSeed denom [ 1, 3 .. denom ]
+                 , let hue = fromIntegral numer * 2 * pi / fromIntegral denom ]
+        doublesOf n = n : doublesOf (2 * n)
+        shuffleSeed k xs = shuffle' xs (length xs) (mkStdGen k)
 
-colorHues :: [Double]
-colorHues = let
-  start = 0.0
-  end = 2*pi
-  foldF :: (Double, Double) -> Maybe (Double, (Double, Double))
-  foldF (level, index) = let
-    pow2 = 2.0 ** (level - 1.0)
-    result = (end - start) * index / pow2
-    index' = mod' (index + pi/8) pow2
-    level' = if (index' == 1.0) then (level+1) else level
-    in Just (result, (level', index'))
-  in unfoldr foldF (1.0, 1.0)
-
-colors :: [Color]
-colors = fmap (\h -> fromHSL h 0.75 0.5) colorHues
 
 hue :: Color -> Double
 hue (RGBA r g b a)

--- a/codeworld-base/src/Internal/Color.hs
+++ b/codeworld-base/src/Internal/Color.hs
@@ -25,7 +25,6 @@ import                           Internal.Num
 import                           Internal.Truth
 import qualified "base"          Prelude as P
 import           "base"          Prelude ((.))
-import Data.Functor (fmap)
 
 newtype Color = RGBA(Number, Number, Number, Number) deriving P.Eq
 type Colour = Color
@@ -101,8 +100,8 @@ gray, grey :: Number -> Color
 gray = fromCWColor . CW.gray . toDouble
 grey = gray
 
-colors :: [Color]
-colors = fmap fromCWColor CW.colors
+assortedColors :: [Color]
+assortedColors = P.map fromCWColor CW.assortedColors
 
 hue, saturation, luminosity :: Color -> Number
 hue = (180 *) . (/ pi) . fromDouble . CW.hue . toCWColor

--- a/codeworld-base/src/Internal/Color.hs
+++ b/codeworld-base/src/Internal/Color.hs
@@ -25,6 +25,7 @@ import                           Internal.Num
 import                           Internal.Truth
 import qualified "base"          Prelude as P
 import           "base"          Prelude ((.))
+import Data.Functor (fmap)
 
 newtype Color = RGBA(Number, Number, Number, Number) deriving P.Eq
 type Colour = Color
@@ -99,6 +100,9 @@ translucent = fromCWColor . CW.translucent . toCWColor
 gray, grey :: Number -> Color
 gray = fromCWColor . CW.gray . toDouble
 grey = gray
+
+rainbow :: Number -> [Color]
+rainbow speed = fmap fromCWColor (CW.rainbow (toDouble speed))
 
 hue, saturation, luminosity :: Color -> Number
 hue = (180 *) . (/ pi) . fromDouble . CW.hue . toCWColor

--- a/codeworld-base/src/Internal/Color.hs
+++ b/codeworld-base/src/Internal/Color.hs
@@ -101,8 +101,8 @@ gray, grey :: Number -> Color
 gray = fromCWColor . CW.gray . toDouble
 grey = gray
 
-rainbow :: Number -> [Color]
-rainbow speed = fmap fromCWColor (CW.rainbow (toDouble speed))
+colors :: [Color]
+colors = fmap fromCWColor CW.colors
 
 hue, saturation, luminosity :: Color -> Number
 hue = (180 *) . (/ pi) . fromDouble . CW.hue . toCWColor

--- a/codeworld-base/src/Internal/Exports.hs
+++ b/codeworld-base/src/Internal/Exports.hs
@@ -54,7 +54,7 @@ module Internal.Exports (
     duller,
     dull,
     translucent,
-    rainbow,
+    colors,
     hue,
     saturation,
     luminosity,

--- a/codeworld-base/src/Internal/Exports.hs
+++ b/codeworld-base/src/Internal/Exports.hs
@@ -54,6 +54,7 @@ module Internal.Exports (
     duller,
     dull,
     translucent,
+    rainbow,
     hue,
     saturation,
     luminosity,

--- a/codeworld-base/src/Internal/Exports.hs
+++ b/codeworld-base/src/Internal/Exports.hs
@@ -54,7 +54,7 @@ module Internal.Exports (
     duller,
     dull,
     translucent,
-    colors,
+    assortedColors,
     hue,
     saturation,
     luminosity,


### PR DESCRIPTION
Simple implementation of this request: https://github.com/google/codeworld/issues/436

A function `rainbow` takes a parameter `speed`.  With a speed of 1.0, `rainbow` produces an infinite list that cycles through the HSL color spectrum in 100 indices.  With a speed of 0.5, this cycle should occur in 200 indices (unless I'm making a trivial algebra mistake :) ).

![selection_152](https://cloud.githubusercontent.com/assets/6315338/25778268/3675e87e-32ae-11e7-83a1-e85b6ba558c7.png)

![selection_151](https://cloud.githubusercontent.com/assets/6315338/25778267/3673b07c-32ae-11e7-8e29-9fb97e6387a8.png)

![selection_150](https://cloud.githubusercontent.com/assets/6315338/25778269/367a2ac4-32ae-11e7-8f90-c260606e95ba.png)

![selection_149](https://cloud.githubusercontent.com/assets/6315338/25778270/368c2058-32ae-11e7-83e8-aa887f690445.png)






