### PR TITLE
Resolve issue, autocomplete inserts at the wrong place when used between two spaces #420

### DIFF
--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -91,6 +91,16 @@ function registerStandardHints(successFunc)
         var cur = cm.getCursor();
         var token = cm.getTokenAt(cur);
         var to = CodeMirror.Pos(cur.line, token.end);
+
+	//To check for the case of insertion in between two parameters
+        r = new RegExp("^\\s+$");
+	// If string is completely made of spaces
+        if (r.test(token.string)) {
+            token.string = token.string.substr(0, cur.ch - token.start);
+            token.end = cur.ch;
+            to = CodeMirror.Pos(cur.line, token.end);
+        }
+
         if (token.string && /\w/.test(token.string[token.string.length - 1])) {
             var term = token.string,
                 from = CodeMirror.Pos(cur.line, token.start);


### PR DESCRIPTION
This Pull Request mainly solves the issue #420. The main problem, in that case, is with the wrong value of `token`. 

Consider an example- If I put 4 spaces and then try to make insertion at position 2 using autocorrect, it add the selected value at the end of four space because of the wrong value in `token.end` with respect to the cursor position. I updated the function for that in `web/js/codeworld_shared.js`. 