### PR TITLE
Fix image size in Guide menu, fixes overflow-x

### DIFF
--- a/web/help/codeworld.md
+++ b/web/help/codeworld.md
@@ -1,4 +1,4 @@
-![](/codeworld.png)
+<img src="/codeworld.png" style="max-width: 100%;">
 
 Welcome to CodeWorld!  CodeWorld is an educational computer programming environment.
 By using a simple mathematical model for geometric shapes and transformations, you


### PR DESCRIPTION
The current Guide menu looks like this : 
![image](https://cloud.githubusercontent.com/assets/11318551/25982886/e260cd9a-36fd-11e7-90b2-f4b22d2d1c0e.png)

Due to this, the vertical x scrollbar gets added which looks conspicuous, especially in hand held devices . The current PR makes sure the image size is that of the menu, hence improves viewability in all types of devices:
![cw](https://cloud.githubusercontent.com/assets/11318551/25982920/29f1e180-36fe-11e7-995f-2e6c9bb026a1.png)
![image](https://cloud.githubusercontent.com/assets/11318551/25982928/443af6ee-36fe-11e7-8451-3e4990a4d527.png)

The overflow-x scrollbar which was not needed will be removed by this PR.
