### PR TITLE
FRP interface reactiveOf

### DIFF
--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -18,6 +18,10 @@ Description:
   package to provide a webpage consisting of just a panel locally. This way, the same
   program that runs on the CodeWorld server can also be run locally.
 
+flag reflex
+    description: Include reactiveOf, the interface to the FRP library reflex
+    default: True
+
 Library
   Hs-source-dirs:      src
   Exposed-modules:     CodeWorld
@@ -35,6 +39,12 @@ Library
                        random                >= 1.1 && < 1.2,
                        cereal                >= 0.5.4 && < 0.6,
                        cereal-text           >= 0.1.0 && < 0.2
+
+  if flag(reflex)
+    Build-depends:
+                       reflex,
+                       dependent-sum
+    cpp-options:       -DREFLEX
 
   if impl(ghcjs)
     Build-depends:

--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -18,10 +18,6 @@ Description:
   package to provide a webpage consisting of just a panel locally. This way, the same
   program that runs on the CodeWorld server can also be run locally.
 
-flag reflex
-    description: Include reactiveOf, the interface to the FRP library reflex
-    default: True
-
 Library
   Hs-source-dirs:      src
   Exposed-modules:     CodeWorld
@@ -38,13 +34,9 @@ Library
                        time                  >= 1.6.0 && < 1.7,
                        random                >= 1.1 && < 1.2,
                        cereal                >= 0.5.4 && < 0.6,
-                       cereal-text           >= 0.1.0 && < 0.2
-
-  if flag(reflex)
-    Build-depends:
-                       reflex,
-                       dependent-sum
-    cpp-options:       -DREFLEX
+                       cereal-text           >= 0.1.0 && < 0.2,
+                       reflex                >= 0.5   && < 0.6,
+                       dependent-sum         >= 0.3   && < 0.4
 
   if impl(ghcjs)
     Build-depends:

--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -26,6 +26,7 @@ Library
                        CodeWorld.Event,
                        CodeWorld.Driver
                        CodeWorld.CollaborationUI
+                       Reflex.SimpleHost
   Build-depends:       base                  >= 4.8 && < 5,
                        containers            >= 0.5.7 && < 0.6,
                        hashable              >= 1.2.4 && < 1.3,

--- a/codeworld-api/src/CodeWorld.hs
+++ b/codeworld-api/src/CodeWorld.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-
   Copyright 2016 The CodeWorld Authors. All rights reserved.
 
@@ -23,6 +25,10 @@ module CodeWorld (
     collaborationOf,
     unsafeCollaborationOf,
 
+#ifdef REFLEX
+    ReactiveInteraction,
+    reactiveOf,
+#endif
     -- * Pictures
     Picture,
     TextStyle(..),

--- a/codeworld-api/src/CodeWorld.hs
+++ b/codeworld-api/src/CodeWorld.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {-
   Copyright 2016 The CodeWorld Authors. All rights reserved.
 
@@ -24,11 +22,9 @@ module CodeWorld (
     interactionOf,
     collaborationOf,
     unsafeCollaborationOf,
-
-#ifdef REFLEX
     ReactiveInteraction,
     reactiveOf,
-#endif
+
     -- * Pictures
     Picture,
     TextStyle(..),

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -38,10 +38,8 @@ module CodeWorld.Driver (
     interactionOf,
     collaborationOf,
     unsafeCollaborationOf,
-#ifdef REFLEX
     ReactiveInteraction,
     reactiveOf,
-#endif
     trace
     ) where
 
@@ -73,16 +71,13 @@ import           System.Mem.StableName
 import           Text.Read
 import           System.Random
 
-#ifdef REFLEX
-
-import Data.IORef
-import Control.Monad.Fix
+-- Stuff for reflex
+import           Data.IORef
+import           Control.Monad.Fix
+import           Data.Functor.Identity
+import           Data.Dependent.Sum (DSum ((:=>)))
 import qualified Reflex as R
 import qualified Reflex.Host.Class as R (newEventWithTriggerRef, runHostFrame, fireEvents)
-import Data.Dependent.Sum (DSum ((:=>)))
-import Data.Functor.Identity
-
-#endif
 
 #ifdef ghcjs_HOST_OS
 
@@ -167,7 +162,6 @@ unsafeCollaborationOf :: Int
                       -> (Int -> world -> Picture)
                       -> IO ()
 
-#ifdef REFLEX
 -- | Alternatively, interactions can be specified in the form of a functional
 -- reactive program, which reacts on UI and time events, and provides a
 -- continuous 'Picture'.
@@ -179,8 +173,6 @@ type ReactiveInteraction t m =
 
 -- | Any such FRP program can be rendered using 'reactiveOf'
 reactiveOf :: (forall t m. ReactiveInteraction t m) -> IO ()
-#endif
-
 
 -- | Prints a debug message to the CodeWorld console when a value is forced.
 -- This is equivalent to the similarly named function in `Debug.Trace`, except
@@ -1065,7 +1057,6 @@ run initial stepHandler eventHandler drawHandler = do
     go t0 nullFrame initialStateName True
 
 
-#ifdef REFLEX
 reactiveOf guest = do
     Just window <- currentWindow
     Just doc <- currentDocument
@@ -1116,7 +1107,6 @@ reactiveOf guest = do
     t0 <- getTime
     nullFrame <- makeStableName undefined
     go t0 nullFrame
-#endif
 
 #else
 
@@ -1216,7 +1206,6 @@ getDeployHash :: IO Text
 getDeployHash = error "game API unimplemented in stand-alone interface mode"
 
 
-#ifdef REFLEX
 reactiveOf guest = runBlankCanvas $ \context -> do
     (eEvent, eEventTriggerRef) <- R.runSpiderHost $ R.newEventWithTriggerRef
     (eTime,  eTimeTriggerRef) <- R.runSpiderHost $ R.newEventWithTriggerRef
@@ -1254,7 +1243,6 @@ reactiveOf guest = runBlankCanvas $ \context -> do
     t0 <- getCurrentTime
     nullFrame <- makeStableName undefined
     go t0 nullFrame
-#endif
 
 runGame :: GameToken
         -> Int

--- a/codeworld-api/src/Reflex/SimpleHost.hs
+++ b/codeworld-api/src/Reflex/SimpleHost.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE RankNTypes              #-}
+
+{-
+  Copyright 2016 The CodeWorld Authors. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-}
+
+-- | The interface to create a new reflex host ist a bit convoluted. Since we
+-- have to do this twice (GHCJS and stand-alone driver), this module creates a
+-- simpler interface for us to use.
+module Reflex.SimpleHost (simpleReflexHost) where
+
+import Data.IORef
+import Control.Monad.Fix
+import Data.Functor.Identity
+import Data.Dependent.Sum (DSum ((:=>)))
+import Reflex
+import Reflex.Host.Class (newEventWithTriggerRef, runHostFrame, fireEvents, EventTrigger)
+
+simpleReflexHost ::
+    (forall t m . (Reflex t, MonadHold t m, MonadFix m)
+              =>  (Event t a, Event t b)
+              ->  (m (Behavior t c)))
+    -> IO (a -> IO (), b -> IO (), IO c)
+simpleReflexHost guest = runSpiderHost $ do
+    (e1, e1TriggerRef) <- newEventWithTriggerRef
+    (e2, e2TriggerRef) <- newEventWithTriggerRef
+    b <- runHostFrame (guest (e1, e2))
+    return
+        ( sendEvent e1TriggerRef
+        , sendEvent e2TriggerRef
+        , runSpiderHost $ runHostFrame $ sample b
+        )
+
+sendEvent :: IORef (Maybe (EventTrigger Spider a)) -> a -> IO ()
+sendEvent eventTriggerRef x =
+    readIORef eventTriggerRef >>= mapM_ (\trig ->
+            runSpiderHost $ fireEvents [trig :=> Identity x])
+


### PR DESCRIPTION
This patch allows users to create interactions by defining a FRP
program, based on the reflex library. The dependency on reflex is
optional, and enabled with -freflex.

This is a result of some hacking with the reflex people at the Compose
Unconference (but all the code in this patch is mine).

A mode where even reactive collaborations are supported depends on some
fancy new feature in reflex, which would allow stats to be reset.

This might be of interest to @ryantrinkle and the other reflex guys.