### PR TITLE
Add debugmode support to animationOf, simulationOf and interactionOf

### DIFF
--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -96,11 +96,9 @@ import           JavaScript.Object
 import           JavaScript.Web.AnimationFrame
 import qualified JavaScript.Web.Canvas as Canvas
 import qualified JavaScript.Web.Canvas.Internal as Canvas
-import qualified JavaScript.Web.Canvas.ImageData as ImageData
 import qualified JavaScript.Web.Location as Loc
 import qualified JavaScript.Web.MessageEvent as WS
 import qualified JavaScript.Web.WebSocket as WS
-import qualified JavaScript.TypedArray as TypedArray
 import           System.IO.Unsafe
 import           Unsafe.Coerce
 

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -370,7 +370,7 @@ findTopPicture ctx ds pic = case pic of
         Canvas.font (fontString sty fnt) ctx
         width <- Canvas.measureText (textToJSString txt) ctx
         let height = 25 -- height is constant, defined in fontString
-        withDS ctx ds $ Canvas.rect ((-0.5)*width) (0.5*height) width height ctx
+        withDS ctx ds $ Canvas.rect ((-0.5)*width) ((-0.5)*height) width height ctx
         contained <- js_isPointInPath 0 0 ctx
         if contained
             then return (Just [pic])

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -379,18 +379,19 @@ findTopPicture ctx ds pic = case pic of
         if contained
             then return (Just [pic])
             else return Nothing
-    Arc _ _ _ _ w      -> do
-        let width = if w==0 then 1 else 25*w
-        Canvas.lineWidth width ctx
-        drawPicture ctx ds pic
+    Arc cs b e r w      -> do
+        -- Thin arcs and paths are drawn bigger to make clicking easier
+        let width = if w==0 then 0.3 else w
+        Canvas.lineWidth (width * 25) ctx
+        drawPicture ctx ds (Arc cs b e r width)
         contained <- js_isPointInStroke 0 0 ctx
         if contained
             then return (Just [pic])
             else return Nothing
-    Path _ _ w _ _     -> do
-        let width = if w==0 then 1 else 25*w
-        Canvas.lineWidth width ctx
-        drawPicture ctx ds pic
+    Path cs ps w c s     -> do
+        let width = if w==0 then 0.3 else w
+        Canvas.lineWidth (width * 25) ctx
+        drawPicture ctx ds (Path cs ps width c s)
         contained <- js_isPointInStroke 0 0 ctx
         if contained
             then return (Just [pic])

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -382,12 +382,14 @@ findTopPicture ctx ds pic = case pic of
             then return (Just [pic])
             else return Nothing
     Arc _ _ _ _ _      -> do
-        contained <- colorDetection
+        drawPicture ctx ds pic
+        contained <- js_isPointInStroke 0 0 ctx
         if contained
             then return (Just [pic])
             else return Nothing
     Path _ _ _ _ _     -> do
-        contained <- colorDetection
+        drawPicture ctx ds pic
+        contained <- js_isPointInStroke 0 0 ctx
         if contained
             then return (Just [pic])
             else return Nothing
@@ -398,23 +400,14 @@ findTopPicture ctx ds pic = case pic of
             then return (Just [pic])
             else return Nothing
     where map2 = fmap . fmap
-          colorDetection = do -- Draws picture in black, uses color to determine if contains mouse
-            Canvas.clearRect 0 0 500 500 ctx
-            drawPicture ctx (blackDS ds) pic
-            imageDataContains <$> js_getImageData 0 0 1 1 ctx
-          blackDS (a,b,c,d,e,f,_) = (a,b,c,d,e,f,Just $ RGBA 1 1 1 1)
-          imageDataContains = (/=0) . js_unsafeIndexUint8ClampedArray 0 . ImageData.getData
 
 -- Canvas.isPointInPath does not provide a way to get the return value
 -- https://github.com/ghcjs/ghcjs-base/blob/master/JavaScript/Web/Canvas.hs#L212
 foreign import javascript unsafe "$3.isPointInPath($1,$2)"
     js_isPointInPath :: Double -> Double -> Canvas.Context -> IO Bool
 
-foreign import javascript unsafe "$5.getImageData($1,$2,$3,$4)"
-    js_getImageData :: Double -> Double -> Double -> Double -> Canvas.Context -> IO Canvas.ImageData
-
-foreign import javascript unsafe "$2[$1]"
-    js_unsafeIndexUint8ClampedArray :: Int -> TypedArray.Uint8ClampedArray -> Int
+foreign import javascript unsafe "$3.isPointInStroke($1,$2)"
+    js_isPointInStroke :: Double -> Double -> Canvas.Context -> IO Bool
 
 foreign import javascript unsafe "initDebugMode($1,$2)"
     js_initDebugMode :: Callback (JSVal -> IO JSVal) -> Callback (JSVal -> IO ()) -> IO ()

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -381,13 +381,17 @@ findTopPicture ctx ds pic = case pic of
         if contained
             then return (Just [pic])
             else return Nothing
-    Arc _ _ _ _ _      -> do
+    Arc _ _ _ _ w      -> do
+        let width = if w==0 then 1 else 25*w
+        Canvas.lineWidth width ctx
         drawPicture ctx ds pic
         contained <- js_isPointInStroke 0 0 ctx
         if contained
             then return (Just [pic])
             else return Nothing
-    Path _ _ _ _ _     -> do
+    Path _ _ w _ _     -> do
+        let width = if w==0 then 1 else 25*w
+        Canvas.lineWidth width ctx
         drawPicture ctx ds pic
         contained <- js_isPointInStroke 0 0 ctx
         if contained

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -96,9 +96,11 @@ import           JavaScript.Object
 import           JavaScript.Web.AnimationFrame
 import qualified JavaScript.Web.Canvas as Canvas
 import qualified JavaScript.Web.Canvas.Internal as Canvas
+import qualified JavaScript.Web.Canvas.ImageData as ImageData
 import qualified JavaScript.Web.Location as Loc
 import qualified JavaScript.Web.MessageEvent as WS
 import qualified JavaScript.Web.WebSocket as WS
+import qualified JavaScript.TypedArray as TypedArray
 import           System.IO.Unsafe
 import           Unsafe.Coerce
 
@@ -379,6 +381,16 @@ findTopPicture ctx ds pic = case pic of
         if contained
             then return (Just [pic])
             else return Nothing
+    Arc _ _ _ _ _      -> do
+        contained <- colorDetection
+        if contained
+            then return (Just [pic])
+            else return Nothing
+    Path _ _ _ _ _     -> do
+        contained <- colorDetection
+        if contained
+            then return (Just [pic])
+            else return Nothing
     _                  -> do
         drawPicture ctx ds pic
         contained <- js_isPointInPath 0 0 ctx
@@ -386,11 +398,23 @@ findTopPicture ctx ds pic = case pic of
             then return (Just [pic])
             else return Nothing
     where map2 = fmap . fmap
+          colorDetection = do -- Draws picture in black, uses color to determine if contains mouse
+            Canvas.clearRect 0 0 500 500 ctx
+            drawPicture ctx (blackDS ds) pic
+            imageDataContains <$> js_getImageData 0 0 1 1 ctx
+          blackDS (a,b,c,d,e,f,_) = (a,b,c,d,e,f,Just $ RGBA 1 1 1 1)
+          imageDataContains = (/=0) . js_unsafeIndexUint8ClampedArray 0 . ImageData.getData
 
 -- Canvas.isPointInPath does not provide a way to get the return value
 -- https://github.com/ghcjs/ghcjs-base/blob/master/JavaScript/Web/Canvas.hs#L212
 foreign import javascript unsafe "$3.isPointInPath($1,$2)"
     js_isPointInPath :: Double -> Double -> Canvas.Context -> IO Bool
+
+foreign import javascript unsafe "$5.getImageData($1,$2,$3,$4)"
+    js_getImageData :: Double -> Double -> Double -> Double -> Canvas.Context -> IO Canvas.ImageData
+
+foreign import javascript unsafe "$2[$1]"
+    js_unsafeIndexUint8ClampedArray :: Int -> TypedArray.Uint8ClampedArray -> Int
 
 foreign import javascript unsafe "initDebugMode($1,$2)"
     js_initDebugMode :: Callback (JSVal -> IO JSVal) -> Callback (JSVal -> IO ()) -> IO ()

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -407,7 +407,8 @@ isDebugModeActive :: IO Bool
 isDebugModeActive = js_isDebugModeActive
 
 setDebugModeActive :: Bool -> IO ()
-setDebugModeActive = js_setDebugModeActive
+setDebugModeActive True  = js_startDebugMode
+setDebugModeActive False = js_stopDebugMode
 
 sweetAlert :: Text -> Text -> Text -> IO ()
 sweetAlert style title msg = js_sweetAlert (textToJSString style) (textToJSString title)
@@ -427,8 +428,11 @@ foreign import javascript unsafe "initDebugMode($1,$2)"
 foreign import javascript unsafe "window.debugMode"
     js_isDebugModeActive :: IO Bool
 
-foreign import javascript unsafe "window.debugMode = $1;parent.updateUI();"
-    js_setDebugModeActive :: Bool -> IO ()
+foreign import javascript unsafe "startDebugMode()"
+    js_startDebugMode :: IO ()
+
+foreign import javascript unsafe "stopDebugMode()"
+    js_stopDebugMode :: IO ()
 
 foreign import javascript unsafe "parent.sweetAlert($2,$3,$1);"
     js_sweetAlert :: JSString -> JSString -> JSString -> IO ()

--- a/web/css/runner.css
+++ b/web/css/runner.css
@@ -6,3 +6,22 @@
     max-height: 100vh;
     max-width: 100vh;
 }
+
+.stack-list {
+    list-style-type: none;
+    padding: 0px;
+}
+
+.stack-list a {
+    color: black;
+    text-decoration: none;
+}
+
+.shape-name {
+    float: left;
+}
+
+.shape-loc {
+    float: right;
+    margin-left: 10px;
+}

--- a/web/css/runner.css
+++ b/web/css/runner.css
@@ -1,0 +1,8 @@
+* { margin: 0; overflow: hidden }
+#screen {
+    cursor: default;
+    width: 100vw;
+    height: 100vw;
+    max-height: 100vh;
+    max-width: 100vh;
+}

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -314,11 +314,18 @@ function updateUI() {
         document.getElementById('deleteButton').style.display = 'none';
     }
 
-    var debugMode = document.getElementById('runner').contentWindow.debugMode;
-    if (debugMode) {
-        document.getElementById('inspectButton').style.color = 'black';
+    var debugAvailable = !!document.getElementById('runner').contentWindow.debugActiveCB;
+    var debugActive = document.getElementById('runner').contentWindow.debugMode;
+    if (debugAvailable) {
+        document.getElementById('inspectButton').style.display = '';
+
+        if (debugActive) {
+            document.getElementById('inspectButton').style.color = 'black';
+        } else {
+            document.getElementById('inspectButton').style.color = '';
+        }
     } else {
-        document.getElementById('inspectButton').style.color = '';
+        document.getElementById('inspectButton').style.display = 'none';
     }
 
     window.move = undefined;
@@ -670,11 +677,9 @@ function run(hash, dhash, msg, error) {
     if (hash) {
         window.location.hash = '#' + hash;
         document.getElementById('shareButton').style.display = '';
-        document.getElementById('inspectButton').style.display = '';
     } else {
         window.location.hash = '';
         document.getElementById('shareButton').style.display = 'none';
-        document.getElementById('inspectButton').style.display = 'none';
     }
 
     if (dhash) {
@@ -713,6 +718,10 @@ function run(hash, dhash, msg, error) {
     window.deployHash = dhash;
 
     updateUI();
+
+    document.getElementById('runner').addEventListener('load', function () {
+        updateUI();
+    });
 }
 
 function goto(line, col) {

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -698,11 +698,7 @@ function share() {
 }
 
 function inspect() {
-    try {
-        document.getElementById('runner').contentWindow.toggleDebugMode();
-    } catch (e) {
-        sweetAlert('Sorry!','Unable to inspect. Inspect is not available in collaborationOf.','error');
-    }
+    document.getElementById('runner').contentWindow.toggleDebugMode();
     updateUI();
 }
 

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -697,7 +697,7 @@ function inspect() {
     try {
         document.getElementById('runner').contentWindow.toggleDebugMode();
     } catch (e) {
-        sweetAlert('Sorry!','Inspect is only available in drawingOf.','error');
+        sweetAlert('Sorry!','Unable to inspect. Inspect is not available in collaborationOf.','error');
     }
     updateUI();
 }

--- a/web/js/debugmode.js
+++ b/web/js/debugmode.js
@@ -92,6 +92,14 @@ function initDebugMode(getStackAtPoint) {
                 infobox.style.top  = evt.clientY + "px";
 
                 infobox.style.display = "block";
+
+                if (evt.clientX + infobox.offsetWidth > 500) {
+                    infobox.style.left = (evt.clientX - infobox.offsetWidth) + "px";
+                }
+
+                if (evt.clientY + infobox.offsetHeight > 500) {
+                    infobox.style.top = (evt.clientY - infobox.offsetHeight) + "px";
+                }
             } else {
                 // If user clicks on a coordinatePlane, stack may contain
                 // only null

--- a/web/js/debugmode.js
+++ b/web/js/debugmode.js
@@ -51,6 +51,9 @@ function initDebugMode(getStackAtPoint, active) {
         if (stack) {
             var pic, i, marker;
             var printable = false;
+            var ul = document.createElement("ul");
+
+            ul.classList.add("stack-list");
 
             infobox.innerHTML = "";
             for (i=stack.length-1;i>=0;i--) {
@@ -71,35 +74,23 @@ function initDebugMode(getStackAtPoint, active) {
                 });
                 debugMarkers.push(marker);
 
-                var link = document.createElement("a");
-                var text = document.createTextNode(
-                        pic.name + "@" + pic.srcLoc.startLine + ":" + stack[i].srcLoc.startCol);
-                var br = document.createElement("br");
-
-                link.href = "#";
-                link.addEventListener("click", (function (pic) {
-                    parent.codeworldEditor.setCursor({
-                        line: pic.srcLoc.startLine-1,
-                        ch: pic.srcLoc.startCol-1
-                    });
-                }).bind(null,pic) );
-
-                link.appendChild(text);
-                infobox.appendChild(link);
-                infobox.appendChild(br);
+                var li = createSrcLink(pic);
+                ul.appendChild(li);
             }
 
             if (printable) {
+                infobox.appendChild(ul);
+
                 infobox.style.left = evt.clientX + "px";
                 infobox.style.top  = evt.clientY + "px";
 
                 infobox.style.display = "block";
 
-                if (evt.clientX + infobox.offsetWidth > 500) {
+                if (evt.clientX + infobox.offsetWidth >= 500) {
                     infobox.style.left = (evt.clientX - infobox.offsetWidth) + "px";
                 }
 
-                if (evt.clientY + infobox.offsetHeight > 500) {
+                if (evt.clientY + infobox.offsetHeight >= 500) {
                     infobox.style.top = (evt.clientY - infobox.offsetHeight) + "px";
                 }
             } else {
@@ -119,6 +110,38 @@ function initDebugMode(getStackAtPoint, active) {
     canvas.onblur = (function (evt) {
         infobox.style.display = "none";
     });
+}
+
+function createSrcLink(pic) {
+    var li = document.createElement("li");
+
+    var preludeLink = "/doc/Prelude.html#v:" + pic.name;
+
+    var shapeName = document.createElement("a");
+    shapeName.classList.add("shape-name");
+    if (parent.buildMode == "codeworld")
+        shapeName.href = preludeLink;
+    shapeName.target = "_blank";
+    var nameText = document.createTextNode(pic.name);
+    shapeName.appendChild(nameText);
+
+    var shapeLoc  = document.createElement("a");
+    shapeLoc.classList.add("shape-loc");
+    shapeLoc.href = "#";
+    var locText = document.createTextNode("@" + pic.srcLoc.startLine + ":" + pic.srcLoc.startCol);
+    shapeLoc.appendChild(locText);
+    shapeLoc.addEventListener("click", function () {
+        parent.codeworldEditor.setCursor({
+            line: pic.srcLoc.startLine - 1,
+            ch: pic.srcLoc.startCol - 1
+        });
+    });
+
+
+    li.appendChild(shapeName);
+    li.appendChild(shapeLoc);
+
+    return li;
 }
 
 function clearMarkers() {

--- a/web/js/debugmode.js
+++ b/web/js/debugmode.js
@@ -115,13 +115,8 @@ function initDebugMode(getStackAtPoint, active) {
 function createSrcLink(pic) {
     var li = document.createElement("li");
 
-    var preludeLink = "/doc/Prelude.html#v:" + pic.name;
-
-    var shapeName = document.createElement("a");
+    var shapeName = document.createElement("span");
     shapeName.classList.add("shape-name");
-    if (parent.buildMode == "codeworld")
-        shapeName.href = preludeLink;
-    shapeName.target = "_blank";
     var nameText = document.createTextNode(pic.name);
     shapeName.appendChild(nameText);
 

--- a/web/js/debugmode.js
+++ b/web/js/debugmode.js
@@ -18,10 +18,11 @@
 
 window.debugMode = false;
 window.debugMarkers = [];
+window.debugActiveCB = null;
 
 window.infobox = null;
 
-function initDebugMode(getStackAtPoint) {
+function initDebugMode(getStackAtPoint, active) {
     var canvas = document.getElementById("screen");
 
     infobox = document.createElement("div");
@@ -34,14 +35,15 @@ function initDebugMode(getStackAtPoint) {
     infobox.id = "infobox";
     document.body.appendChild(infobox);
 
+    window.debugActiveCB = active;
+
     canvas.addEventListener("click", function (evt) {
         if (!debugMode) return;
 
-        var ret = {};
-        getStackAtPoint({
+        var ret = getStackAtPoint({
             x: evt.clientX,
             y: evt.clientY,
-        }, ret);
+        });
 
         clearMarkers();
 
@@ -130,6 +132,7 @@ function startDebugMode() {
         throw new Error("Can't start debugMode: isPointInPath not registered via initDebugMode!");
     }
     window.debugMode = true;
+    window.debugActiveCB(true);
 }
 
 function stopDebugMode() {
@@ -138,6 +141,7 @@ function stopDebugMode() {
     }
     window.debugMode = false;
     clearMarkers();
+    window.debugActiveCB(false);
 }
 
 function toggleDebugMode() {

--- a/web/js/debugmode.js
+++ b/web/js/debugmode.js
@@ -156,6 +156,7 @@ function startDebugMode() {
     }
     window.debugMode = true;
     window.debugActiveCB(true);
+    parent.updateUI();
 }
 
 function stopDebugMode() {
@@ -165,6 +166,7 @@ function stopDebugMode() {
     window.debugMode = false;
     clearMarkers();
     window.debugActiveCB(false);
+    parent.updateUI();
 }
 
 function toggleDebugMode() {

--- a/web/run.html
+++ b/web/run.html
@@ -3,16 +3,7 @@
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,Number.isFinite,Number.isInteger,console,console.log,document.head,performance.now"></script>
   <head>
     <title>CodeWorld</title>
-    <style type="text/css">
-      * { margin: 0; overflow: hidden }
-      #screen {
-          cursor: default;
-          width: 100vw;
-          height: 100vw;
-          max-height: 100vh;
-          max-width: 100vh;
-      }
-    </style>
+    <link rel="stylesheet" type="text/css" href="css/runner.css">
   </head>
   <body style="text-align: center">
     <canvas id="screen"></canvas>


### PR DESCRIPTION
This PR adds support for debugmode to animationOf, simulationOf and interactionOf. The animationOf and simulationOf entry must be paused before inspecting. The interactionOf entrypoint will automatically pause by clicking Inspect and will not receive events while paused. This PR should also fix bugs #521, #516 and #517.

The `isPointInStroke` function is used for strokes, consistent with `isPointInPath` for solid shapes. Line numbers in infobox are better aligned and names link to their documentation. The inspect button will only show if available. Pausing was originally implemented by holding an MVar that was released when leaving debugmode, but is now implemented as wrappers around states and events that is cleaner and requires less changes. An unreported bug where text couldn't be properly inspected was fixed.