### PR TITLE
Add OS X package manager and GHC architecture detection

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -36,5 +36,5 @@ function run {
 }
 
 function cabal_install {
-  cabal install --force-reinstalls --global --prefix=$BUILD $@
+  cabal install --disable-library-profiling --force-reinstalls --global --prefix=$BUILD $@
 }

--- a/install.sh
+++ b/install.sh
@@ -118,6 +118,44 @@ then
   run . sudo zypper -n install patch
   run . sudo zypper -n install autoconf
   run . sudo zypper -n install automake
+elif type brew > /dev/null 2> /dev/null
+then
+  echo Detected 'brew': Installing packages from there.
+  echo
+
+  # install missing packages -- don't try to upgrade already installed packages
+  function brew_install {
+    if ! brew ls $1 > /dev/null 2> /dev/null
+    then
+      run . brew install $1
+    fi
+  }
+
+  # Update and install basic dependencies
+  xcode-select --install
+
+  brew_install git
+  brew_install curl
+  brew_install wget
+  brew_install bzip2
+# No psmisc in homebrew
+  #brew_install psmisc
+
+#  brew_install ncurses-devel
+
+  # Needed for GHC 7.8
+  brew_install make
+  brew_install gcc
+  #brew_install gmp-devel
+
+  # Needed for GHCJS
+  brew_install node@6
+
+  # Needed for ghcjs-boot --dev
+  # already present on OS X
+  #brew_install patch
+  brew_install autoconf
+  brew_install automake
 else
   echo "WARNING: Could not find package manager."
   echo "Make sure necessary packages are installed."
@@ -128,6 +166,8 @@ if /sbin/ldconfig -p | grep -q libgmp.so.10; then
   GHC_ARCH=`uname -m`-deb8-linux
 elif /sbin/ldconfig -p | grep -q libgmp.so.3; then
   GHC_ARCH=`uname -m`-centos67-linux
+elif uname | grep -q Darwin; then
+  GHC_ARCH=`uname -m`-apple-darwin
 else
   echo Sorry, but no supported libgmp is installed.
   exit 1


### PR DESCRIPTION
This works on my machine, and it's possible that I have some dependencies already installed.

It runs OK, but when I run the logo demo I get the error messages:

Line 30, Column 48: error: Missing parentheses in function application
Line 42, Column 31: error: Missing parentheses in function application
Line 43, Column 31: error: Missing parentheses in function application

even though the logo seems to be produced correctly.
<img width="1427" alt="screen shot 2018-03-24 at 10 32 47 pm" src="https://user-images.githubusercontent.com/3942/37863527-6f1cf3ea-2fb3-11e8-87ef-4f0b2074dbc5.png">
