### PR TITLE
Add SolidClosedCurve

### DIFF
--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -210,8 +210,8 @@ type DrawState = (Double, Double, Double, Double, Double, Double, Maybe Color)
 type NodeId = Int
 
 pictureToDrawing :: Picture -> Drawing
-pictureToDrawing (SolidClosedCurve _ pts s) = Shape $ polygonDrawer pts True
-pictureToDrawing (SolidPolygon _ pts s) = Shape $ polygonDrawer pts False
+pictureToDrawing (SolidClosedCurve _ pts ) = Shape $ polygonDrawer pts True
+pictureToDrawing (SolidPolygon _ pts ) = Shape $ polygonDrawer pts False
 pictureToDrawing (Path _ pts w c s) = Shape $ pathDrawer pts w c s
 pictureToDrawing (Sector _ b e r) = Shape $ sectorDrawer b e r
 pictureToDrawing (Arc _ b e r w) = Shape $ arcDrawer b e r w
@@ -439,15 +439,15 @@ picToObj = fmap fst . flip State.runStateT 0 . picToObj'
 picToObj' :: Picture -> State.StateT Int IO JSVal
 picToObj' pic =
     case pic of
-        SolidPolygon cs pts smooth -> do
+        SolidPolygon cs pts -> do
             obj <- init "solidPolygon"
             ptsJS <- pointsToArr pts
-            setProps [("points", ptsJS), ("smooth", pToJSVal smooth)] obj
+            setProps [("points", ptsJS), ("smooth", pToJSVal True)] obj
             retVal obj
-        SolidClosedCurve cs pts smooth -> do
+        SolidClosedCurve cs pts -> do
             obj <- init "solidClosedCurve"
             ptsJS <- pointsToArr pts
-            setProps [("points", ptsJS), ("smooth", pToJSVal smooth)] obj
+            setProps [("points", ptsJS), ("smooth", pToJSVal False)] obj
             retVal obj
         Path cs pts w closed smooth -> do
             obj <- init "path"
@@ -573,8 +573,8 @@ findCSMain cs =
     Data.List.find ((== "main") . srcLocPackage . snd) (getCallStack cs)
 
 getPictureCS :: Picture -> CallStack
-getPictureCS (SolidPolygon cs _ _) = cs
-getPictureCS (SolidClosedCurve cs _ _) = cs
+getPictureCS (SolidPolygon cs _ ) = cs
+getPictureCS (SolidClosedCurve cs _ ) = cs
 getPictureCS (Path cs _ _ _ _) = cs
 getPictureCS (Sector cs _ _ _) = cs
 getPictureCS (Arc cs _ _ _ _) = cs

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -210,8 +210,8 @@ type DrawState = (Double, Double, Double, Double, Double, Double, Maybe Color)
 type NodeId = Int
 
 pictureToDrawing :: Picture -> Drawing
-pictureToDrawing (SolidClosedCurve _ pts s) = Shape $ polygonDrawer pts s
-pictureToDrawing (SolidPolygon _ pts s) = Shape $ polygonDrawer pts s
+pictureToDrawing (SolidClosedCurve _ pts s) = Shape $ polygonDrawer pts True
+pictureToDrawing (SolidPolygon _ pts s) = Shape $ polygonDrawer pts False
 pictureToDrawing (Path _ pts w c s) = Shape $ pathDrawer pts w c s
 pictureToDrawing (Sector _ b e r) = Shape $ sectorDrawer b e r
 pictureToDrawing (Arc _ b e r w) = Shape $ arcDrawer b e r w

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -210,6 +210,7 @@ type DrawState = (Double, Double, Double, Double, Double, Double, Maybe Color)
 type NodeId = Int
 
 pictureToDrawing :: Picture -> Drawing
+pictureToDrawing (SolidClosedCurve _ pts s) = Shape $ polygonDrawer pts s
 pictureToDrawing (SolidPolygon _ pts s) = Shape $ polygonDrawer pts s
 pictureToDrawing (Path _ pts w c s) = Shape $ pathDrawer pts w c s
 pictureToDrawing (Sector _ b e r) = Shape $ sectorDrawer b e r
@@ -443,6 +444,11 @@ picToObj' pic =
             ptsJS <- pointsToArr pts
             setProps [("points", ptsJS), ("smooth", pToJSVal smooth)] obj
             retVal obj
+        SolidClosedCurve cs pts smooth -> do
+            obj <- init "SolidClosedCurve"
+            ptsJS <- pointsToArr pts
+            setProps [("points", ptsJS), ("smooth", pToJSVal smooth)] obj
+            retVal obj
         Path cs pts w closed smooth -> do
             obj <- init "path"
             ptsJS <- pointsToArr pts
@@ -568,6 +574,7 @@ findCSMain cs =
 
 getPictureCS :: Picture -> CallStack
 getPictureCS (SolidPolygon cs _ _) = cs
+getPictureCS (SolidClosedCurve cs _ _) = cs
 getPictureCS (Path cs _ _ _ _) = cs
 getPictureCS (Sector cs _ _ _) = cs
 getPictureCS (Arc cs _ _ _ _) = cs

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -445,7 +445,7 @@ picToObj' pic =
             setProps [("points", ptsJS), ("smooth", pToJSVal smooth)] obj
             retVal obj
         SolidClosedCurve cs pts smooth -> do
-            obj <- init "SolidClosedCurve"
+            obj <- init "solidClosedCurve"
             ptsJS <- pointsToArr pts
             setProps [("points", ptsJS), ("smooth", pToJSVal smooth)] obj
             retVal obj

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -210,8 +210,8 @@ type DrawState = (Double, Double, Double, Double, Double, Double, Maybe Color)
 type NodeId = Int
 
 pictureToDrawing :: Picture -> Drawing
-pictureToDrawing (SolidClosedCurve _ pts ) = Shape $ polygonDrawer pts True
-pictureToDrawing (SolidPolygon _ pts ) = Shape $ polygonDrawer pts False
+pictureToDrawing (SolidClosedCurve _ pts) = Shape $ polygonDrawer pts True
+pictureToDrawing (SolidPolygon _ pts) = Shape $ polygonDrawer pts False
 pictureToDrawing (Path _ pts w c s) = Shape $ pathDrawer pts w c s
 pictureToDrawing (Sector _ b e r) = Shape $ sectorDrawer b e r
 pictureToDrawing (Arc _ b e r w) = Shape $ arcDrawer b e r w

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -573,8 +573,8 @@ findCSMain cs =
     Data.List.find ((== "main") . srcLocPackage . snd) (getCallStack cs)
 
 getPictureCS :: Picture -> CallStack
-getPictureCS (SolidPolygon cs _ ) = cs
-getPictureCS (SolidClosedCurve cs _ ) = cs
+getPictureCS (SolidPolygon cs _) = cs
+getPictureCS (SolidClosedCurve cs _) = cs
 getPictureCS (Path cs _ _ _ _) = cs
 getPictureCS (Sector cs _ _ _) = cs
 getPictureCS (Arc cs _ _ _ _) = cs

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -442,12 +442,12 @@ picToObj' pic =
         SolidPolygon cs pts -> do
             obj <- init "solidPolygon"
             ptsJS <- pointsToArr pts
-            setProps [("points", ptsJS), ("smooth", pToJSVal True)] obj
+            setProps [("points", ptsJS), ("smooth", pToJSVal False)] obj
             retVal obj
         SolidClosedCurve cs pts -> do
             obj <- init "solidClosedCurve"
             ptsJS <- pointsToArr pts
-            setProps [("points", ptsJS), ("smooth", pToJSVal False)] obj
+            setProps [("points", ptsJS), ("smooth", pToJSVal True)] obj
             retVal obj
         Path cs pts w closed smooth -> do
             obj <- init "path"

--- a/codeworld-api/src/CodeWorld/Picture.hs
+++ b/codeworld-api/src/CodeWorld/Picture.hs
@@ -51,6 +51,9 @@ data Picture
     = SolidPolygon CallStack
               [Point]
               !Bool
+    | SolidClosedCurve CallStack
+              [Point]
+              !Bool
     | Path CallStack
            [Point]
            !Double
@@ -167,7 +170,7 @@ thickLoop n ps = Path callStack ps n True True
 
 -- | A solid smooth closed curve passing through these points.
 solidClosedCurve :: HasCallStack => [Point] -> Picture
-solidClosedCurve ps = SolidPolygon callStack ps True
+solidClosedCurve ps = SolidClosedCurve callStack ps True
 
 -- | A solid smooth closed curve passing through these points.
 solidLoop :: HasCallStack => [Point] -> Picture

--- a/codeworld-api/src/CodeWorld/Picture.hs
+++ b/codeworld-api/src/CodeWorld/Picture.hs
@@ -50,10 +50,8 @@ dotProduct (x1, y1) (x2, y2) = x1 * x2 + y1 * y2
 data Picture
     = SolidPolygon CallStack
               [Point]
-              !Bool
     | SolidClosedCurve CallStack
               [Point]
-              !Bool
     | Path CallStack
            [Point]
            !Double
@@ -138,7 +136,7 @@ thickPolygon n ps = Path callStack ps n True False
 
 -- | A solid polygon with these points as vertices
 solidPolygon :: HasCallStack => [Point] -> Picture
-solidPolygon ps = SolidPolygon callStack ps False
+solidPolygon ps = SolidPolygon callStack ps
 
 -- | A smooth curve passing through these points.
 curve :: HasCallStack => [Point] -> Picture
@@ -170,11 +168,11 @@ thickLoop n ps = Path callStack ps n True True
 
 -- | A solid smooth closed curve passing through these points.
 solidClosedCurve :: HasCallStack => [Point] -> Picture
-solidClosedCurve ps = SolidClosedCurve callStack ps True
+solidClosedCurve ps = SolidClosedCurve callStack ps
 
 -- | A solid smooth closed curve passing through these points.
 solidLoop :: HasCallStack => [Point] -> Picture
-solidLoop ps = SolidPolygon callStack ps True
+solidLoop ps = SolidPolygon callStack ps
 
 {-# WARNING solidLoop "Please use solidClosedCurve instead of solidLoop." #-}
 

--- a/codeworld-api/src/CodeWorld/Picture.hs
+++ b/codeworld-api/src/CodeWorld/Picture.hs
@@ -172,7 +172,7 @@ solidClosedCurve ps = SolidClosedCurve callStack ps
 
 -- | A solid smooth closed curve passing through these points.
 solidLoop :: HasCallStack => [Point] -> Picture
-solidLoop ps = SolidPolygon callStack ps
+solidLoop ps = SolidClosedCurve callStack ps
 
 {-# WARNING solidLoop "Please use solidClosedCurve instead of solidLoop." #-}
 


### PR DESCRIPTION
```solidPolygon``` function still uses ```SolidPolygon``` constructor and ```solidClosedCurve``` uses SolidClosedCurve. It type-checks, but not sure if I did anything wrong ;/