### PR TITLE
Splitting Arc and ThickArc in Picture - type checks first attempt

### DIFF
--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -221,7 +221,7 @@ pictureToDrawing (ThickPolyline _ pts w) = Shape $ pathDrawer pts w False False
 pictureToDrawing (Curve _ pts) = Shape $ pathDrawer pts 0 False True
 pictureToDrawing (ThickCurve _ pts w) = Shape $ pathDrawer pts w False True
 pictureToDrawing (Sector _ b e r) = Shape $ sectorDrawer b e r
-pictureToDrawing (Arc _ b e r w) = Shape $ arcDrawer b e r 0
+pictureToDrawing (Arc _ b e r) = Shape $ arcDrawer b e r 0
 pictureToDrawing (ThickArc _ b e r w) = Shape $ arcDrawer b e r w
 pictureToDrawing (Text _ sty fnt txt) = Shape $ textDrawer sty fnt txt
 pictureToDrawing (Logo _) = Shape $ logoDrawer
@@ -554,7 +554,7 @@ picToObj' pic =
                 ]
                 obj
             retVal obj
-        Arc cs b e r w -> do
+        Arc cs b e r -> do
             obj <- init "arc"
             setProps
                 [ ("startAngle", pToJSVal b)
@@ -679,7 +679,7 @@ getPictureCS (ThickPolyline cs _ _) = cs
 getPictureCS (Curve cs _) = cs
 getPictureCS (ThickCurve cs _ _) = cs
 getPictureCS (Sector cs _ _ _) = cs
-getPictureCS (Arc cs _ _ _ _) = cs
+getPictureCS (Arc cs _ _ _) = cs
 getPictureCS (ThickArc cs _ _ _ _) = cs
 getPictureCS (Text cs _ _ _) = cs
 getPictureCS (Color cs _ _) = cs

--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -221,7 +221,8 @@ pictureToDrawing (ThickPolyline _ pts w) = Shape $ pathDrawer pts w False False
 pictureToDrawing (Curve _ pts) = Shape $ pathDrawer pts 0 False True
 pictureToDrawing (ThickCurve _ pts w) = Shape $ pathDrawer pts w False True
 pictureToDrawing (Sector _ b e r) = Shape $ sectorDrawer b e r
-pictureToDrawing (Arc _ b e r w) = Shape $ arcDrawer b e r w
+pictureToDrawing (Arc _ b e r w) = Shape $ arcDrawer b e r 0
+pictureToDrawing (ThickArc _ b e r w) = Shape $ arcDrawer b e r w
 pictureToDrawing (Text _ sty fnt txt) = Shape $ textDrawer sty fnt txt
 pictureToDrawing (Logo _) = Shape $ logoDrawer
 pictureToDrawing (CoordinatePlane _) = Shape $ coordinatePlaneDrawer
@@ -559,6 +560,16 @@ picToObj' pic =
                 [ ("startAngle", pToJSVal b)
                 , ("endAngle", pToJSVal e)
                 , ("radius", pToJSVal r)
+                , ("width", pToJSVal (0 :: Double))
+                ]
+                obj
+            retVal obj
+        ThickArc cs b e r w -> do
+            obj <- init "thickArc"
+            setProps
+                [ ("startAngle", pToJSVal b)
+                , ("endAngle", pToJSVal e)
+                , ("radius", pToJSVal r)
                 , ("width", pToJSVal w)
                 ]
                 obj
@@ -669,6 +680,7 @@ getPictureCS (Curve cs _) = cs
 getPictureCS (ThickCurve cs _ _) = cs
 getPictureCS (Sector cs _ _ _) = cs
 getPictureCS (Arc cs _ _ _ _) = cs
+getPictureCS (ThickArc cs _ _ _ _) = cs
 getPictureCS (Text cs _ _ _) = cs
 getPictureCS (Color cs _ _) = cs
 getPictureCS (Translate cs _ _ _) = cs

--- a/codeworld-api/src/CodeWorld/Picture.hs
+++ b/codeworld-api/src/CodeWorld/Picture.hs
@@ -81,6 +81,11 @@ data Picture
           !Double
           !Double
           !Double
+    | ThickArc CallStack
+          !Double
+          !Double
+          !Double
+          !Double
     | Text CallStack
            !TextStyle
            !Font
@@ -228,7 +233,7 @@ arc b e r = Arc callStack b e r 0
 --
 -- Angles are in radians.
 thickArc :: HasCallStack => Double -> Double -> Double -> Double -> Picture
-thickArc w b e r = Arc callStack b e r w
+thickArc w b e r = ThickArc callStack b e r w
 
 -- | A solid circle, with this radius
 solidCircle :: HasCallStack => Double -> Picture

--- a/codeworld-api/src/CodeWorld/Picture.hs
+++ b/codeworld-api/src/CodeWorld/Picture.hs
@@ -80,7 +80,6 @@ data Picture
           !Double
           !Double
           !Double
-          !Double
     | ThickArc CallStack
           !Double
           !Double
@@ -226,7 +225,7 @@ thickCircle w = thickArc w 0 (2 * pi)
 --
 -- Angles are in radians.
 arc :: HasCallStack => Double -> Double -> Double -> Picture
-arc b e r = Arc callStack b e r 0
+arc b e r = Arc callStack b e r
 
 -- | A thick arc with this line width, starting and ending at these angles,
 -- with this radius.


### PR DESCRIPTION
What needs to be removed here? I've initially just passed ```0``` for Arc and Thickline has ```w``` and made it type-check.