### PR TITLE
Fix simulationOf stepButton

### DIFF
--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -2671,7 +2671,7 @@ animationOf f = runInspect animationControls 0 (+) (\_ r -> r) f
 simulationControls :: Wrapped w -> [Control w]
 simulationControls w
     | lastInteractionTime w > 5 = []
-    | playbackSpeed w == 0 = [PlayButton (-8, -9), StepButton (-6, -9),
+    | playbackSpeed w == 0 = [PlayButton (-8, -9), StepButton (-2, -9),
                               SpeedSlider (-6, -9), FastForwardButton (-4, -9)]
     | otherwise = [PauseButton (-8, -9), FastForwardButton (-4, -9),
                    SpeedSlider (-6, -9)]


### PR DESCRIPTION
stepButton in simulationOf was in wrong place.
This moves the button to a better place.