### PR TITLE
Move toolbar out of jQuery-layout and allow line-wrapping of buttons.

### DIFF
--- a/web/blocks.html
+++ b/web/blocks.html
@@ -38,70 +38,70 @@
     </script>
   </head>
   <body>
-    <div id="nav" class="dropbox ui-layout-west">
-      <div class="nav_items">
-        <a id="newFolderButton" class="cw-button red" onclick="newFolder()">
-          <i class="mdi mdi-18px mdi-folder"></i>&nbsp; New Folder
-        </a>
-        <a id="newButton" class="cw-button red" onclick="newProject()">
-          <i class="mdi mdi-18px mdi-plus"></i>&nbsp; New
-        </a>
-        <a id="saveButton" class="cw-button blue" style="display:none" onclick="saveProject()">
-          <i class="mdi mdi-18px mdi-cloud-upload"></i>&nbsp; Save
-        </a>
-        <a id="saveAsButton" class="cw-button blue" onclick="saveProjectAs()">
-          <i class="mdi mdi-18px mdi-dots-horizontal"></i>&nbsp; Save As
-        </a>
-        <a id="deleteButton" class="cw-button red" style="display:none" onclick="deleteProject()">
-          <i class="mdi mdi-18px mdi-delete"></i>&nbsp; Delete
-        </a>
-        <a id="moveButton" class="cw-button blue" style="display:none" onclick="moveProject()">
-          <i class="mdi mdi-18px mdi-folder-move"></i>&nbsp; Move
-        </a>
-        <a id="moveHereButton" class="cw-button blue" style="display:none" onclick="moveHere()">
-          <i class="mdi mdi-18px mdi-folder-download"></i>&nbsp; Move Here
-        </a>
-        <a id="cancelMoveButton" class="cw-button red" style="display:none" onclick="cancelMove()">
-          <i class="mdi mdi-18px mdi-close-circle"></i>&nbsp; Cancel
-        </a>
+    <div class="ui-layout-container">
+      <div id="nav" class="dropbox ui-layout-west">
+        <div class="nav_items">
+          <a id="newFolderButton" class="cw-button red" onclick="newFolder()">
+            <i class="mdi mdi-18px mdi-folder"></i>&nbsp; New Folder
+          </a>
+          <a id="newButton" class="cw-button red" onclick="newProject()">
+            <i class="mdi mdi-18px mdi-plus"></i>&nbsp; New
+          </a>
+          <a id="saveButton" class="cw-button blue" style="display:none" onclick="saveProject()">
+            <i class="mdi mdi-18px mdi-cloud-upload"></i>&nbsp; Save
+          </a>
+          <a id="saveAsButton" class="cw-button blue" onclick="saveProjectAs()">
+            <i class="mdi mdi-18px mdi-dots-horizontal"></i>&nbsp; Save As
+          </a>
+          <a id="deleteButton" class="cw-button red" style="display:none" onclick="deleteProject()">
+            <i class="mdi mdi-18px mdi-delete"></i>&nbsp; Delete
+          </a>
+          <a id="moveButton" class="cw-button blue" style="display:none" onclick="moveProject()">
+            <i class="mdi mdi-18px mdi-folder-move"></i>&nbsp; Move
+          </a>
+          <a id="moveHereButton" class="cw-button blue" style="display:none" onclick="moveHere()">
+            <i class="mdi mdi-18px mdi-folder-download"></i>&nbsp; Move Here
+          </a>
+          <a id="cancelMoveButton" class="cw-button red" style="display:none" onclick="cancelMove()">
+            <i class="mdi mdi-18px mdi-close-circle"></i>&nbsp; Cancel
+          </a>
+        </div>
+        <div class="nav_items" id="nav_mine"></div>
       </div>
-      <div class="nav_items" id="nav_mine"></div>
+
+
+      <div class="dropbox ui-layout-center" id="blocklyDiv" style="height: 84%; width:100%;"> </div>
+
+      <div id="result" style="display:none" class="ui-layout-east">
+        <iframe id="runner" class="dropbox" width="500" height="500"
+        style="display:none;"></iframe>
+
+        <pre id="message" class="dropbox" style="width:100%; min-height:100px;
+        padding:5px;display:none;"></pre>
+
+        <span><a type="button" style="margin-top:5px;" id="editButton" target="_blank" class="cw-button blue">
+              <span>Edit code</span>
+        </a> 
+        </span>
+        <pre id="genCode" class="dropbox cm-s-default CodeMirror"
+        style="width:100%; height:100%; padding:10px;">
+        </pre> 
+      </div>
     </div>
-
-
-    <div class="dropbox ui-layout-center" id="blocklyDiv" style="height: 84%; width:100%;"> </div>
-
-    <div id="result" style="display:none" class="ui-layout-east">
-      <iframe id="runner" class="dropbox" width="500" height="500"
-      style="display:none;"></iframe>
-
-      <pre id="message" class="dropbox" style="width:100%; min-height:100px;
-      padding:5px;display:none;"></pre>
-
-      <span><a type="button" style="margin-top:5px;" id="editButton" target="_blank" class="cw-button blue">
-            <span>Edit code</span>
-      </a> 
-      </span>
-      <pre id="genCode" class="dropbox cm-s-default CodeMirror"
-      style="width:100%; height:100%; padding:10px;">
-      </pre> 
-    </div>
-    <div class="ui-layout-south">
-      <div id="toolbar">
-        <div id="buttons">
-          <a id="navButton" class="cw-button blue" onclick="window.mainLayout.toggle('west')"><i class="mdi mdi-18px mdi-menu"></i></a>
-          <a id="signin"  class="cw-button blue" onclick="signin()"><i class="mdi mdi-18px mdi-login"></i>&nbsp; Sign In</a>
-          <a id="signout" class="cw-button blue" style="display:none" onclick="signout()"><i class="mdi mdi-18px mdi-logout"></i>&nbsp; Sign Out</a>
-          <a id="docButton" class="cw-button blue" onclick="help()"><i class="mdi mdi-18px mdi-book-open-variant"></i>&nbsp; Help</a>
-          <a id="bugButton" class="cw-button blue" target="_blank" href="https://github.com/google/codeworld/issues/new?labels=funblocks"><i class="mdi mdi-18px mdi-bug"></i>&nbsp; Report Bug</a>
-        </div>
-        <span></span>
-        <div id="runButtons">
-          <a id="shareFolderButton" class="cw-button yellow" style="display:none" onclick="shareFolder()"><i class="mdi mdi-18px mdi-folder-outline"></i>&nbsp; Share Folder</a>
-          <a id="shareButton" class="cw-button yellow" style="display:none" onclick="share()"><i class="mdi mdi-18px mdi-share"></i>&nbsp; Share</a>
-          <a class="cw-button red" id="btnStop"><i class="mdi mdi-18px mdi-stop"></i>&nbsp; Stop</a>
-          <a class="cw-button green" id="btnRun"><i class="mdi mdi-18px mdi-play"></i>&nbsp; Run</a>
-        </div>
+    <div id="toolbar">
+      <div id="buttons">
+        <a id="navButton" class="cw-button blue" onclick="window.mainLayout.toggle('west')"><i class="mdi mdi-18px mdi-menu"></i></a>
+        <a id="signin"  class="cw-button blue" onclick="signin()"><i class="mdi mdi-18px mdi-login"></i>&nbsp; Sign In</a>
+        <a id="signout" class="cw-button blue" style="display:none" onclick="signout()"><i class="mdi mdi-18px mdi-logout"></i>&nbsp; Sign Out</a>
+        <a id="docButton" class="cw-button blue" onclick="help()"><i class="mdi mdi-18px mdi-book-open-variant"></i>&nbsp; Help</a>
+        <a id="bugButton" class="cw-button blue" target="_blank" href="https://github.com/google/codeworld/issues/new?labels=funblocks"><i class="mdi mdi-18px mdi-bug"></i>&nbsp; Report Bug</a>
+      </div>
+      <span></span>
+      <div id="runButtons">
+        <a id="shareFolderButton" class="cw-button yellow" style="display:none" onclick="shareFolder()"><i class="mdi mdi-18px mdi-folder-outline"></i>&nbsp; Share Folder</a>
+        <a id="shareButton" class="cw-button yellow" style="display:none" onclick="share()"><i class="mdi mdi-18px mdi-share"></i>&nbsp; Share</a>
+        <a class="cw-button red" id="btnStop"><i class="mdi mdi-18px mdi-stop"></i>&nbsp; Stop</a>
+        <a class="cw-button green" id="btnRun"><i class="mdi mdi-18px mdi-play"></i>&nbsp; Run</a>
       </div>
     </div>
 
@@ -138,13 +138,8 @@
     <script src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-layout/1.4.3/jquery.layout_and_plugins.min.js"></script>
     <script type="text/javascript">
-      window.mainLayout = $('body').layout({
+      window.mainLayout = $('.ui-layout-container').layout({
         default: {},
-        south: {
-          resizable: false,
-          closable: false,
-          enableCursorHotkey: false
-        },
         west: {
           initHidden: true,
           minSize: 50,

--- a/web/css/codeworld.css
+++ b/web/css/codeworld.css
@@ -17,10 +17,26 @@
 html { height: 100%; width: 100%; }
 
 body {
+  align-items: stretch;
+  -webkit-align-items: stretch;
+  -ms-align-items: stretch;
   height: 100%;
   background-color: #e5eff9;
+  display: flex;
+  display: -webkit-flex;
+  display: -ms-flex;
+  flex-direction: column;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
   margin: 0px;
   overflow: hidden;
+}
+
+.ui-layout-container {
+  flex: 1 1 auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  padding-bottom: 5px;
 }
 
 #toolbar {
@@ -33,24 +49,27 @@ body {
   flex-direction: row;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
-}
-
-#toolbar div {
   flex: 0 0 auto;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
-  display: flex;
-  display: -webkit-flex;
-  display: -ms-flex;
+}
+
+#toolbar > div {
   align-items: stretch;
   -webkit-align-items: stretch;
   -ms-align-items: stretch;
-  flex-direction: row;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
+  display: flex;
+  display: -webkit-flex;
+  display: -ms-flex;
+  flex: 0 1 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex-flow: row wrap;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
 }
 
-#toolbar span {
+#toolbar > span {
   flex: 1 1 auto;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
@@ -130,6 +149,7 @@ body {
   -ms-flex-direction: column;
 
   margin: 0px;
+  overflow-y: auto;
 }
 
 #runner {
@@ -295,6 +315,7 @@ body {
   background-color: white;
   border: solid #cccccc 1px;
   box-shadow: 1px 1px 2px #000;
+  box-sizing: border-box;
   margin: 2px 4px 4px 2px;
 }
 

--- a/web/env.html
+++ b/web/env.html
@@ -140,7 +140,7 @@
           runner.focus();
         }
         wasDraggingEast = isDraggingEast;
-      }).observe(document.body, {childList: true});
+      }).observe(document.querySelector('.ui-layout-container'), {childList: true});
     </script>
     <script type="text/javascript" src="//wurfl.io/wurfl.js"></script>
     <script type="text/javascript" src="js/codemirror-compressed.js" charset="UTF-8"></script>

--- a/web/env.html
+++ b/web/env.html
@@ -43,67 +43,67 @@
     </script>
   </head>
   <body>
-    <div id="nav" class="dropbox ui-layout-west">
-      <div class="nav_items">
-        <a id="newFolderButton" class="cw-button red" onclick="newFolder()">
-            <i class="mdi mdi-18px mdi-folder"></i>&nbsp; New Folder
-        </a>
-        <a id="newButton" class="cw-button red" onclick="newProject()">
-          <i class="mdi mdi-18px mdi-plus"></i>&nbsp; New
-        </a>
-        <a id="saveButton" class="cw-button blue" style="display:none" onclick="saveProject()">
-          <i class="mdi mdi-18px mdi-cloud-upload"></i>&nbsp; Save
-        </a>
-        <a id="saveAsButton" class="cw-button blue" onclick="saveProjectAs()">
-          <i class="mdi mdi-18px mdi-dots-horizontal"></i>&nbsp; Save As
-        </a>
-        <a id="deleteButton" class="cw-button red" style="display:none" onclick="deleteProject()">
-          <i class="mdi mdi-18px mdi-delete"></i>&nbsp; Delete
-        </a>
-        <a id="downloadButton" class="cw-button blue" onclick="downloadProject()">
-          <i class="mdi mdi-18px mdi-download"></i>&nbsp; Download
-        </a>
-        <a id="moveButton" class="cw-button blue" style="display:none" onclick="moveProject()">
-          <i class="mdi mdi-18px mdi-folder-move"></i>&nbsp; Move
-        </a>
-        <a id="moveHereButton" class="cw-button blue" style="display:none" onclick="moveHere()">
-          <i class="mdi mdi-18px mdi-folder-download"></i>&nbsp; Move Here
-        </a>
-        <a id="cancelMoveButton" class="cw-button red" style="display:none" onclick="cancelMove()">
-          <i class="mdi mdi-18px mdi-close-circle"></i>&nbsp; Cancel
-        </a>
+    <div class="ui-layout-container">
+      <div id="nav" class="dropbox ui-layout-west">
+        <div class="nav_items">
+          <a id="newFolderButton" class="cw-button red" onclick="newFolder()">
+              <i class="mdi mdi-18px mdi-folder"></i>&nbsp; New Folder
+          </a>
+          <a id="newButton" class="cw-button red" onclick="newProject()">
+            <i class="mdi mdi-18px mdi-plus"></i>&nbsp; New
+          </a>
+          <a id="saveButton" class="cw-button blue" style="display:none" onclick="saveProject()">
+            <i class="mdi mdi-18px mdi-cloud-upload"></i>&nbsp; Save
+          </a>
+          <a id="saveAsButton" class="cw-button blue" onclick="saveProjectAs()">
+            <i class="mdi mdi-18px mdi-dots-horizontal"></i>&nbsp; Save As
+          </a>
+          <a id="deleteButton" class="cw-button red" style="display:none" onclick="deleteProject()">
+            <i class="mdi mdi-18px mdi-delete"></i>&nbsp; Delete
+          </a>
+          <a id="downloadButton" class="cw-button blue" onclick="downloadProject()">
+            <i class="mdi mdi-18px mdi-download"></i>&nbsp; Download
+          </a>
+          <a id="moveButton" class="cw-button blue" style="display:none" onclick="moveProject()">
+            <i class="mdi mdi-18px mdi-folder-move"></i>&nbsp; Move
+          </a>
+          <a id="moveHereButton" class="cw-button blue" style="display:none" onclick="moveHere()">
+            <i class="mdi mdi-18px mdi-folder-download"></i>&nbsp; Move Here
+          </a>
+          <a id="cancelMoveButton" class="cw-button red" style="display:none" onclick="cancelMove()">
+            <i class="mdi mdi-18px mdi-close-circle"></i>&nbsp; Cancel
+          </a>
+        </div>
+        <div class="nav_items" id="nav_mine"></div>
       </div>
-      <div class="nav_items" id="nav_mine"></div>
-    </div>
 
-    <form id="source" class="dropbox ui-layout-center"><textarea id="editor" placeholder="Type your code here..."></textarea></form>
+      <form id="source" class="dropbox ui-layout-center"><textarea id="editor" placeholder="Type your code here..."></textarea></form>
 
-    <div id="result" style="display:none" class="ui-layout-east">
-      <iframe id="runner" class="dropbox"></iframe>
-      <pre id="message" class="dropbox"></pre>
+      <div id="result" style="display:none" class="ui-layout-east">
+        <iframe id="runner" class="dropbox"></iframe>
+        <pre id="message" class="dropbox"></pre>
+      </div>
     </div>
-    <div class="ui-layout-south">
-      <div id="toolbar">
-        <div id="buttons">
-          <a id="navButton" class="cw-button blue" onclick="window.mainLayout.toggle('west')"><i class="mdi mdi-18px mdi-menu"></i></a>
-          <a id="signin"  class="cw-button blue" onclick="signin()"><i class="mdi mdi-18px mdi-login"></i>&nbsp; Sign In</a>
-          <a id="editorHelp"  class="cw-button blue" onclick="editorHelp()"><i class="mdi mdi-18px mdi-keyboard"></i>&nbsp; Editor</a>
-          <a id="signout" class="cw-button blue" style="display:none" onclick="signout()"><i class="mdi mdi-18px mdi-logout"></i>&nbsp; Sign Out</a>
-          <a id="docButton" class="cw-button blue" onclick="help()"><i class="mdi mdi-18px mdi-book-open-variant"></i>&nbsp; Guide</a>
-          <a id="helpButton" class="cw-button blue" target="_blank" href="http://help.code.world"><i class="mdi mdi-18px mdi-comment-question-outline"></i>&nbsp; Ask a Question</a>
-          <a id="bugButton" class="cw-button blue" target="_blank" href="https://github.com/google/codeworld/issues/new?template=bug_report.md"><i class="mdi mdi-18px mdi-bug"></i>&nbsp; Report a Bug</a>
-        </div>
-        <span></span>
-        <div id="runButtons">
-          <a id="shareFolderButton" class="cw-button yellow" style="display:none" onclick="shareFolder()"><i class="mdi mdi-18px mdi-folder-outline"></i>&nbsp; Share Folder</a>
-          <span><i class="mdi mdi-24px mdi-record" style="display:none" id="recordIcon"><!--Recording Icon--></i></span>
-          <a id="startRecButton" style="display:none" class="cw-button red" onclick="captureStart()"><i class="mdi mdi-18px mdi-record"></i>&nbsp; Start Recording</a>
-          <a id="stopRecButton" style="display:none" class="cw-button yellow" onclick="stopRecording()"><i class="mdi mdi-18px mdi-stop"></i>&nbsp; Stop Recording</a>
-          <a id="shareButton" class="cw-button yellow" style="display:none" onclick="share()"><i class="mdi mdi-18px mdi-share"></i>&nbsp; Share</a>
-          <a id="inspectButton" class="cw-button cyan" style="display:none" onclick="inspect()"><i class="mdi mdi-18px mdi-magnify"></i>&nbsp; Inspect</a>
-          <a class="cw-button red" onclick="stop()"><i class="mdi mdi-18px mdi-stop"></i>&nbsp; Stop</a>
-          <a class="cw-button green" onclick="compile()"><i class="mdi mdi-18px mdi-play"></i>&nbsp; Run</a>
-        </div>
+    <div id="toolbar">
+      <div id="buttons">
+        <a id="navButton" class="cw-button blue" onclick="window.mainLayout.toggle('west')"><i class="mdi mdi-18px mdi-menu"></i></a>
+        <a id="signin"  class="cw-button blue" onclick="signin()"><i class="mdi mdi-18px mdi-login"></i>&nbsp; Sign In</a>
+        <a id="editorHelp"  class="cw-button blue" onclick="editorHelp()"><i class="mdi mdi-18px mdi-keyboard"></i>&nbsp; Editor</a>
+        <a id="signout" class="cw-button blue" style="display:none" onclick="signout()"><i class="mdi mdi-18px mdi-logout"></i>&nbsp; Sign Out</a>
+        <a id="docButton" class="cw-button blue" onclick="help()"><i class="mdi mdi-18px mdi-book-open-variant"></i>&nbsp; Guide</a>
+        <a id="helpButton" class="cw-button blue" target="_blank" href="http://help.code.world"><i class="mdi mdi-18px mdi-comment-question-outline"></i>&nbsp; Ask a Question</a>
+        <a id="bugButton" class="cw-button blue" target="_blank" href="https://github.com/google/codeworld/issues/new?template=bug_report.md"><i class="mdi mdi-18px mdi-bug"></i>&nbsp; Report a Bug</a>
+      </div>
+      <span></span>
+      <div id="runButtons">
+        <a id="shareFolderButton" class="cw-button yellow" style="display:none" onclick="shareFolder()"><i class="mdi mdi-18px mdi-folder-outline"></i>&nbsp; Share Folder</a>
+        <span><i class="mdi mdi-24px mdi-record" style="display:none" id="recordIcon"><!--Recording Icon--></i></span>
+        <a id="startRecButton" style="display:none" class="cw-button red" onclick="captureStart()"><i class="mdi mdi-18px mdi-record"></i>&nbsp; Start Recording</a>
+        <a id="stopRecButton" style="display:none" class="cw-button yellow" onclick="stopRecording()"><i class="mdi mdi-18px mdi-stop"></i>&nbsp; Stop Recording</a>
+        <a id="shareButton" class="cw-button yellow" style="display:none" onclick="share()"><i class="mdi mdi-18px mdi-share"></i>&nbsp; Share</a>
+        <a id="inspectButton" class="cw-button cyan" style="display:none" onclick="inspect()"><i class="mdi mdi-18px mdi-magnify"></i>&nbsp; Inspect</a>
+        <a class="cw-button red" onclick="stop()"><i class="mdi mdi-18px mdi-stop"></i>&nbsp; Stop</a>
+        <a class="cw-button green" onclick="compile()"><i class="mdi mdi-18px mdi-play"></i>&nbsp; Run</a>
       </div>
     </div>
 
@@ -111,13 +111,8 @@
     <script src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-layout/1.4.3/jquery.layout_and_plugins.min.js"></script>
     <script type="text/javascript">
-      window.mainLayout = $('body').layout({
+      window.mainLayout = $('.ui-layout-container').layout({
         default: {},
-        south: {
-          resizable: false,
-          closable: false,
-          enableCursorHotkey: false
-        },
         west: {
           initHidden: true,
           minSize: 50,


### PR DESCRIPTION
Fixes #732 by allowing the toolbar to wrap and also taking it out of the jQuery-layout so that it can vertically size itself appropriately without javascript (since this resize sometimes fails to do so with jQuery-layout).
This PR also includes a minor fix to allow vertical scroll when the content overflows in the results pane.

One subtle glitch is that if you zoom in a LOT, then attempting to resize the result canvas to be smaller (drag mouse on the separator) sometimes catches in the middle and doesn't resize further. See, e.g., this GIF:
![resize](https://user-images.githubusercontent.com/370338/45921525-40175980-be85-11e8-9892-ae840b903713.gif)
When zooming back out, it behaves fine. WDYT?

Further notes:

1. One can implement lighter-weight resizable sections using the [CSS resize property](https://developer.mozilla.org/en-US/docs/Web/CSS/resize) that might make it easier to control the layout; however, this feature not yet supported by Edge.
2. This project might want to consider incorporating [a CSS auto-prefixer](https://github.com/postcss/autoprefixer) to avoid needing to manually add/maintain vendor prefixes.
