### PR TITLE
fix(install): initialize color variables for non color capable terminals

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -19,6 +19,10 @@ export PATH=$BUILD/bin:$PATH
 export LANG=${LANG:-C.UTF-8}
 export PREFIX=$BUILD
 
+setnormal=""
+setred=""
+setgreen=""
+setyellow=""
 if test -t 1; then
   ncolors=$(tput colors)
   if test -n "$ncolors" && test "$ncolors" -ge 8; then


### PR DESCRIPTION
Fixes the following error : 
```
base.sh: line 52: setgreen: unbound variable
```
when running install on a non color capable terminal, for example when building a docker image.