### PR TITLE
Add chessai as an honorary contributor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,6 +13,7 @@
 Fernando Alegre <alphalambda@fernando.alemor.org>
 Peter Becich <peterbecich@gmail.com>
 Joachim Breitner <mail@joachim-breitner.de>
+Daniel Cartwright <chessai1996@gmail.com>
 Richard Cook <rcook@rcook.org>
 Josh Cough <joshcough@gmail.com>
 Tom Davies <tgdavies@gmail.com>


### PR DESCRIPTION
Although the contribution was technically to GHC, chessai is helping to make it much easier to build and deploy CodeWorld by avoiding the need to patch GHC.

@chessai