### PR TITLE
Use an exact value for translation instead of a badly rounded one

### DIFF
--- a/web/help/examples.md
+++ b/web/help/examples.md
@@ -68,8 +68,8 @@ top = go(5)
         go(n) = let sub = scaled(go (n-1), 1/3, 1/3)
                in pictures([ translated(sub, -8/3, 0),
                              translated(sub,  8/3, 0),
-                             translated(rotated(sub,  60), -2/3, 1.12),
-                             translated(rotated(sub, 300),  2/3, 1.12) ])
+                             translated(rotated(sub,  60), -2/3, 2/sqrt(3)),
+                             translated(rotated(sub, 300),  2/3, 2/sqrt(3)) ])
 
 bottom = scaled(top, 1, -1)
 ~~~~~


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/16061266/51878791-e9dc8a80-233e-11e9-893b-ed6875ae2c2b.PNG)

After:
![after](https://user-images.githubusercontent.com/16061266/51878801-efd26b80-233e-11e9-815c-deaaabc72d48.PNG)