### PR TITLE
Show CodeMirror compress error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,7 @@ function build_codemirror {
   exitcode=$?
   if [ $exitcode -ne 0 ]; then
     cat codemirror-compressed.js
+    rm codemirror-compressed.js
   fi
   return $exitcode
 }

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,11 @@ function build_codemirror {
                text-hover \
     --local node_modules/uglify-js/bin/uglifyjs \
     > codemirror-compressed.js
+  exitcode=$?
+  if [ $exitcode -ne 0 ]; then
+    cat codemirror-compressed.js
+  fi
+  return $exitcode
 }
 
 run $BUILD/CodeMirror build_codemirror


### PR DESCRIPTION
If this fails, it writes the error to stdout instead of stderr.
Detect this and print the output if this happens.