### PR TITLE
Install gnupg before running NodeSource setup on apt/deb systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,7 @@ then
   run . sudo apt-get install -y libgmp-dev
 
   # Needed for GHCJS
+  run . sudo apt-get install -y gnupg
   run --quiet . curl -sL https://deb.nodesource.com/setup_8.x | run . sudo -E bash -
   run . sudo apt-get install -y nodejs
 


### PR DESCRIPTION
On apt/deb systems, NodeSource adds its GPG key to apt, and fails if
gnupg isn't installed:

```
## Adding the NodeSource signing key to your keyring...

+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
```