### PR TITLE
Use CSS transforms instead of playing with font-size for brackets

### DIFF
--- a/web/css/codeworld-cm.css
+++ b/web/css/codeworld-cm.css
@@ -35,8 +35,8 @@ pre.cm-s-default span.cm-meta,       div.CodeMirror span.cm-meta       {color: #
 pre.cm-s-default span.cm-qualifier,  div.CodeMirror span.cm-qualifier  {color: #666;}
 pre.cm-s-default span.cm-number,     div.CodeMirror span.cm-number     {color: #a10;}
 pre.cm-s-default span.cm-bracket,    div.CodeMirror span.cm-bracket    {color: #000;}
-pre.cm-s-default span.cm-bracket-0,  div.CodeMirror span.cm-bracket-0  {font-weight: bold; color: hsl( 80, 80%, 40%); font-size: 1.25em; letter-spacing: -0.12em}
-pre.cm-s-default span.cm-bracket-1,  div.CodeMirror span.cm-bracket-1  {font-weight: bold; color: hsl(225, 60%, 60%); font-size: 1.12em; letter-spacing: -0.064em;}
+pre.cm-s-default span.cm-bracket-0,  div.CodeMirror span.cm-bracket-0  {font-weight: bold; color: hsl( 80, 80%, 40%); transform: scale(1.25); display: inline-block;}
+pre.cm-s-default span.cm-bracket-1,  div.CodeMirror span.cm-bracket-1  {font-weight: bold; color: hsl(225, 60%, 60%); transform: scale(1.12); display: inline-block;}
 pre.cm-s-default span.cm-bracket-2,  div.CodeMirror span.cm-bracket-2  {font-weight: bold; color: hsl(320, 60%, 50%);}
 pre.cm-s-default span.cm-bracket-3,  div.CodeMirror span.cm-bracket-3  {font-weight: bold; color: hsl( 60, 60%, 40%);}
 pre.cm-s-default span.cm-bracket-4,  div.CodeMirror span.cm-bracket-4  {font-weight: bold; color: hsl(175, 60%, 40%);}


### PR DESCRIPTION
This fixes part of #812, and also fixes vertical line spacing changing
due to parentheses.