### PR TITLE
Closes #885

### DIFF
--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -994,7 +994,10 @@ function compile() {
     sweetAlert({
         title: Alert.title('Compiling'),
         text: 'Your code is compiling.  Please wait...',
-        onOpen: sweetAlert.showLoading,
+        onOpen: () => {
+           sweetAlert.showLoading();
+           sweetAlert.getCancelButton().disabled = false;
+        },
         showConfirmButton: false,
         showCancelButton: true,
         showCloseButton: false,


### PR DESCRIPTION
This bug occurred because `showLoading()` disables the cancel button when invoked