### PR TITLE
WIP for docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 *.hi
 *.jsexe
 *.swp
+*~
 nohup.out
 web/closure-library
 third_party/closure-library

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+MAINTAINER Brandon Barker <brandon.barker@cornell.edu>
+
+ARG GIT_COMMIT
+
+RUN apt update -y
+
+RUN apt install -y --no-install-recommends \
+    ca-certificates git sudo && \
+  mkdir /work && \
+  cd /work && \
+  git clone https://github.com/google/codeworld.git && \
+  cd codeworld && \
+  git checkout $GIT_COMMIT && \
+  ./install.sh
+
+RUN echo "#!/usr/bin/env bash\n\$@\n" > /opt/entrypoint && \
+  chmod a+x /opt/entrypoint
+
+ENTRYPOINT ["/opt/entrypoint"]
+

--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ If you make changes to CodeWorld, you can rebuild it without rebuilding the depe
 2. Run `./build.sh` to recompile just CodeWorld itself, using previously installed tools and libraries.
 3. Run `./run.sh` to start the server.
 
+Docker
+-------
+
+### To use the image from Docker Hub
+
+`TODO`
+
+### To build a new image
+
+`GIT_COMMIT=<commit> ./build-docker.sh`
+
+or just `./build-docker.sh` to use the commit that is currently
+checked out in your local repository.
+
 Caveats
 -------
 
@@ -96,7 +110,9 @@ Caveats
 While the installation process installs most of its files inside `codeworld/build`, it does
 clobber `~/.ghc`, `~/.ghcjs`, and `~/.cabal`.  I recommend that you run CodeWorld as a
 dedicated user account to avoid causing problems for other Haskell installations.  If you
-don't, note that you will lose your user package database.
+don't, note that you will lose your user package database. Alternatively, if you use
+the docker container, this isolates the aforementioned directories so they will
+not be clobbered.
 
 See bug [#4](https://github.com/google/codeworld/issues/4) for details.
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+GIT_SHORT=$(git rev-parse --short HEAD)
+GIT_COMMIT=${GIT_COMMIT:$GIT_SHORT}
+docker build \
+       --build-arg GIT_COMMIT="$GIT_COMMIT" \
+       -t codeworld:latest -f Dockerfile .

--- a/install.sh
+++ b/install.sh
@@ -210,7 +210,9 @@ fi
 GHC_DIR=8.0.2
 GHC_VERSION=8.0.2
 
-run $DOWNLOADS               wget http://downloads.haskell.org/~ghc/$GHC_DIR/ghc-$GHC_VERSION-$GHC_ARCH.tar.xz
+WGET_ARGS="--progress=bar:force:noscroll"
+
+run $DOWNLOADS               wget $WGET_ARGS http://downloads.haskell.org/~ghc/$GHC_DIR/ghc-$GHC_VERSION-$GHC_ARCH.tar.xz
 run $BUILD                   tar xf $DOWNLOADS/ghc-$GHC_VERSION-$GHC_ARCH.tar.xz
 run $BUILD/ghc-$GHC_VERSION  ./configure --prefix=$BUILD
 run $BUILD/ghc-$GHC_VERSION  make install
@@ -218,7 +220,7 @@ run $BUILD                   rm -rf ghc-$GHC_VERSION
 
 # Now install the patched GHC, built from source.
 
-run $DOWNLOADS               wget https://downloads.haskell.org/~ghc/$GHC_DIR/ghc-$GHC_VERSION-src.tar.xz
+run $DOWNLOADS               wget $WGET_ARGS https://downloads.haskell.org/~ghc/$GHC_DIR/ghc-$GHC_VERSION-src.tar.xz
 run $BUILD                   tar xf $DOWNLOADS/ghc-$GHC_VERSION-src.tar.xz
 run .                        patch -p0 -u -d $BUILD < ghc-artifacts/ghc-$GHC_VERSION-default-main.patch
 run .                        cp ghc-artifacts/build.mk $BUILD/ghc-$GHC_VERSION/mk/build.mk
@@ -229,7 +231,7 @@ run $BUILD                   rm -rf ghc-$GHC_VERSION
 
 # Install all the dependencies for cabal
 
-run $DOWNLOADS                     wget https://www.haskell.org/cabal/release/cabal-install-2.0.0.0/cabal-install-2.0.0.0.tar.gz
+run $DOWNLOADS                     wget $WGET_ARGS https://www.haskell.org/cabal/release/cabal-install-2.0.0.0/cabal-install-2.0.0.0.tar.gz
 run $BUILD                         tar xf $DOWNLOADS/cabal-install-2.0.0.0.tar.gz
 EXTRA_CONFIGURE_OPTS="" run $BUILD/cabal-install-2.0.0.0 ./bootstrap.sh
 run .                              cabal update


### PR DESCRIPTION
Please do not merge yet.

The hope is that this will be, upon initial release, the container will be useful for both development and production, and will document the two different use cases. Since the development docker image may take much more storage than necessary for a runtime codeworld environment (though I'm not sure how much more, since codeworld still includes a ghc compiler), it is possible we might want to have two separate images in the future, but personally I'm not too worried about it.

Once working, we should think about under what repository to publish the images to: e.g., `https://hub.docker.com/u/google`, `https://hub.docker.com/u/bbarker`, or the (currently non existent) `https://hub.docker.com/u/codeworld`, or something else.

I'll be pasting some diagnostic output soon (once I have it again); the current situation though is that curl seems to hang when fetching mtl. I seemingly needed to alter the `wget` arguments to avoid a hang there as well, though I'm not sure if it is related.