### PR TITLE
Tooltip pane

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,6 @@ function build_codemirror {
       addon/dialog/dialog.js \
       addon/display/placeholder.js \
       addon/display/rulers.js \
-      addon/display/panel.js \
       addon/edit/matchbrackets.js \
       addon/hint/show-hint.js \
       addon/lint/lint.js \

--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,7 @@ function build_codemirror {
       addon/dialog/dialog.js \
       addon/display/placeholder.js \
       addon/display/rulers.js \
+      addon/display/panel.js \
       addon/edit/matchbrackets.js \
       addon/hint/show-hint.js \
       addon/lint/lint.js \

--- a/third_party/MaterialDesign/content-copy.svg
+++ b/third_party/MaterialDesign/content-copy.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="content-copy.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/MaterialDesign/content-cut.svg
+++ b/third_party/MaterialDesign/content-cut.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="content-cut.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M19,3L13,9L15,11L22,4V3M12,12.5A0.5,0.5 0 0,1 11.5,12A0.5,0.5 0 0,1 12,11.5A0.5,0.5 0 0,1 12.5,12A0.5,0.5 0 0,1 12,12.5M6,20A2,2 0 0,1 4,18C4,16.89 4.9,16 6,16A2,2 0 0,1 8,18C8,19.11 7.1,20 6,20M6,8A2,2 0 0,1 4,6C4,4.89 4.9,4 6,4A2,2 0 0,1 8,6C8,7.11 7.1,8 6,8M9.64,7.64C9.87,7.14 10,6.59 10,6A4,4 0 0,0 6,2A4,4 0 0,0 2,6A4,4 0 0,0 6,10C6.59,10 7.14,9.87 7.64,9.64L10,12L7.64,14.36C7.14,14.13 6.59,14 6,14A4,4 0 0,0 2,18A4,4 0 0,0 6,22A4,4 0 0,0 10,18C10,17.41 9.87,16.86 9.64,16.36L12,14L19,21H22V20L9.64,7.64Z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/MaterialDesign/content-paste.svg
+++ b/third_party/MaterialDesign/content-paste.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="content-paste.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M19,20H5V4H7V7H17V4H19M12,2A1,1 0 0,1 13,3A1,1 0 0,1 12,4A1,1 0 0,1 11,3A1,1 0 0,1 12,2M19,2H14.82C14.4,0.84 13.3,0 12,0C10.7,0 9.6,0.84 9.18,2H5A2,2 0 0,0 3,4V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V4A2,2 0 0,0 19,2Z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/MaterialDesign/content-save.svg
+++ b/third_party/MaterialDesign/content-save.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="save.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+     id="path4"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/MaterialDesign/magnify.svg
+++ b/third_party/MaterialDesign/magnify.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="magnify.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/MaterialDesign/redo.svg
+++ b/third_party/MaterialDesign/redo.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg128"
+   sodipodi:docname="redo.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata134">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview130"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="19.222183"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg128" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path124" />
+  <path
+     d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z"
+     id="path126"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/MaterialDesign/undo.svg
+++ b/third_party/MaterialDesign/undo.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="undo.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="756"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+     id="path4"
+     style="fill:#ffffff" />
+</svg>

--- a/third_party/codemirror-buttons/LICENSE.md
+++ b/third_party/codemirror-buttons/LICENSE.md
@@ -1,0 +1,32 @@
+The Yii framework is free software. It is released under the terms of
+the following BSD License.
+
+Copyright © 2016 by Alexander Makarov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+ * Neither the name of Yii Software LLC nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/codemirror-buttons/LOCAL_CHANGES.diff
+++ b/third_party/codemirror-buttons/LOCAL_CHANGES.diff
@@ -1,0 +1,7 @@
+42c42
+<             buttonNode = document.createElement('button');
+---
+>             buttonNode = document.createElement('div');
+44,45d43
+<             buttonNode.setAttribute('type', 'button');
+<             buttonNode.setAttribute('tabindex', '-1');

--- a/third_party/codemirror-buttons/buttons.js
+++ b/third_party/codemirror-buttons/buttons.js
@@ -1,0 +1,68 @@
+(function (mod) {
+    if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
+        mod(
+            require('codemirror/lib/codemirror'),
+            require('codemirror/addon/display/panel')
+        );
+    }
+    else if (typeof define === 'function' && define.amd) { // AMD
+        define([
+            'codemirror/lib/codemirror',
+            'codemirror/addon/display/panel'
+        ], mod);
+    }
+    else { // Plain browser env
+        mod(CodeMirror);
+    }
+})(function (CodeMirror) {
+    "use strict";
+
+    var PANEL_ELEMENT_CLASS = "CodeMirror-buttonsPanel";
+
+    CodeMirror.defineOption("buttons", [], function (cm, value, old) {
+        var panelNode = document.createElement("div");
+        panelNode.className = PANEL_ELEMENT_CLASS;
+        for (var i = 0, len = value.length; i < len; i++) {
+            var button = createButton(cm, value[i]);
+            panelNode.appendChild(button);
+        }
+        cm.addPanel(panelNode);
+    });
+
+    function createButton(cm, config) {
+        var buttonNode;
+
+        if (config.el) {
+            if (typeof config.el === 'function') {
+                buttonNode = config.el(cm);
+            } else {
+                buttonNode = config.el;
+            }
+        } else {
+            buttonNode = document.createElement('div');
+            buttonNode.innerHTML = config.label;
+
+            buttonNode.addEventListener('click', function (e) {
+                e.preventDefault();
+                cm.focus();
+                config.callback(cm);
+            });
+
+            if (config.class) {
+                buttonNode.className = config.class;
+            }
+
+            if (config.title) {
+                buttonNode.setAttribute('title', config.title);
+            }
+        }
+
+        if (config.hotkey) {
+            var map = {};
+            map[config.hotkey] = config.callback;
+            cm.addKeyMap(CodeMirror.normalizeKeyMap(map));
+        }
+
+        return buttonNode;
+    }
+});

--- a/web/css/codeworld-cm.css
+++ b/web/css/codeworld-cm.css
@@ -386,12 +386,13 @@ span:not(.cm-layout)+span.cm-layout:before {
 }
 
 #source .CodeMirror {
-    position: relative;
+    top: 4em;
 }
 
 .CodeMirror-buttonsPanel {
     margin-bottom: .1em;
-    position: relative;
+    position: absolute;
+    width: 100%;
     padding-left: 1em;
 }
 

--- a/web/css/codeworld-cm.css
+++ b/web/css/codeworld-cm.css
@@ -392,35 +392,46 @@ span:not(.cm-layout)+span.cm-layout:before {
 .CodeMirror-buttonsPanel {
     margin-bottom: .1em;
     position: relative;
-    border-bottom: 1px solid #aaaaaa;
-    padding-bottom: 3px;
+    padding-left: 1em;
 }
 
-.CodeMirror-buttonsPanel div {
+.CodeMirror-buttonsPanel div.cw-toolbar-button {
+    display: inline-block;
+    padding: 0.5em 0.5em 0em 0.5em;
+    margin: 0.5em 0.5em 0em 0.5em;
     text-align: center;
-    width: 2em;
-    height: 2em;
+    width: 1em;
+    height: 1em;
+    filter: brightness(75%);
+}
+
+.CodeMirror-buttonsPanel div.cw-toolbar-button:hover {
+    filter: brightness(50%);
+}
+
+.CodeMirror-buttonsPanel div.cw-toolbar-button:active {
+    transform: translate(2px, 2px);
+    filter: brightness(25%);
 }
 
 .cw-button-cut {
-    background: url("/ims/content-cut.svg") no-repeat center center;
+    background: url("/ims/content-cut.svg") no-repeat center;
 }
 .cw-button-copy {
-    background: url("/ims/content-copy.svg") no-repeat center center;
+    background: url("/ims/content-copy.svg") no-repeat center;
 }
 .cw-button-paste {
-    background: url("/ims/content-paste.svg") no-repeat center center;
+    background: url("/ims/content-paste.svg") no-repeat center;
 }
 .cw-button-redo {
-    background: url("/ims/redo.svg") no-repeat center center;
+    background: url("/ims/redo.svg") no-repeat center;
 }
 .cw-button-undo {
-    background: url("/ims/undo.svg") no-repeat center center;
+    background: url("/ims/undo.svg") no-repeat center;
 }
 .cw-button-save {
-    background: url("/ims/content-save.svg") no-repeat center center;
+    background: url("/ims/content-save.svg") no-repeat center;
 }
-
 .cw-button-search {
-    background: url("/ims/magnify.svg") no-repeat center center;
+    background: url("/ims/magnify.svg") no-repeat center;
 }

--- a/web/css/codeworld-cm.css
+++ b/web/css/codeworld-cm.css
@@ -384,3 +384,43 @@ span:not(.cm-layout)+span.cm-layout:before {
 .CodeMirror pre.CodeMirror-placeholder {
     padding-left: 0.5em;
 }
+
+#source .CodeMirror {
+    position: relative;
+}
+
+.CodeMirror-buttonsPanel {
+    margin-bottom: .1em;
+    position: relative;
+    border-bottom: 1px solid #aaaaaa;
+    padding-bottom: 3px;
+}
+
+.CodeMirror-buttonsPanel div {
+    text-align: center;
+    width: 2em;
+    height: 2em;
+}
+
+.cw-button-cut {
+    background: url("/ims/content-cut.svg") no-repeat center center;
+}
+.cw-button-copy {
+    background: url("/ims/content-copy.svg") no-repeat center center;
+}
+.cw-button-paste {
+    background: url("/ims/content-paste.svg") no-repeat center center;
+}
+.cw-button-redo {
+    background: url("/ims/redo.svg") no-repeat center center;
+}
+.cw-button-undo {
+    background: url("/ims/undo.svg") no-repeat center center;
+}
+.cw-button-save {
+    background: url("/ims/content-save.svg") no-repeat center center;
+}
+
+.cw-button-search {
+    background: url("/ims/magnify.svg") no-repeat center center;
+}

--- a/web/env.html
+++ b/web/env.html
@@ -181,6 +181,7 @@
     </script>
     <script type="text/javascript" src="//wurfl.io/wurfl.js"></script>
     <script type="text/javascript" src="js/codemirror-compressed.js" charset="UTF-8"></script>
+    <script type="text/javascript" src="js/codemirror-buttons/buttons.js"></script>
     <script type="text/javascript" src="js/details-element-polyfill.js"></script>
     <script type="text/javascript" src="js/codeworld-mode.js"></script>
     <script type="text/javascript" src="js/codeworld_shared.js"></script>

--- a/web/ims/content-copy.svg
+++ b/web/ims/content-copy.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/content-copy.svg

--- a/web/ims/content-cut.svg
+++ b/web/ims/content-cut.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/content-cut.svg

--- a/web/ims/content-paste.svg
+++ b/web/ims/content-paste.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/content-paste.svg

--- a/web/ims/content-save.svg
+++ b/web/ims/content-save.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/content-save.svg

--- a/web/ims/magnify.svg
+++ b/web/ims/magnify.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/magnify.svg

--- a/web/ims/redo.svg
+++ b/web/ims/redo.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/redo.svg

--- a/web/ims/undo.svg
+++ b/web/ims/undo.svg
@@ -1,0 +1,1 @@
+../../third_party/MaterialDesign/undo.svg

--- a/web/js/codemirror-buttons/buttons.js
+++ b/web/js/codemirror-buttons/buttons.js
@@ -1,0 +1,1 @@
+../../../third_party/codemirror-buttons/buttons.js

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -57,6 +57,8 @@ async function init() {
     window.cancelCompile = () => {};
     window.clipboard = '';
 
+    definePanelExtension();
+
     initCodeworld();
     registerStandardHints(() => {
         setMode(true);

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -212,7 +212,7 @@ function initCodeworld() {
         },
         buttons: [
             {
-                class: 'cw-button blue cw-button-save',
+                class: 'cw-toolbar-button cw-button-save',
                 label: '',
                 title: 'Save',
                 callback: function (cm) {
@@ -220,7 +220,7 @@ function initCodeworld() {
                 }
             },
             {
-                class: 'cw-button blue cw-button-search',
+                class: 'cw-toolbar-button cw-button-search',
                 label: '',
                 title: 'Search',
                 callback: function (cm) {
@@ -228,7 +228,7 @@ function initCodeworld() {
                 }
             },
             {
-                class: 'cw-button blue cw-button-undo',
+                class: 'cw-toolbar-button cw-button-undo',
                 label: '',
                 title: 'Undo',
                 callback: function (cm) {
@@ -236,7 +236,7 @@ function initCodeworld() {
                 }
             },
             {
-                class: 'cw-button blue cw-button-redo',
+                class: 'cw-toolbar-button cw-button-redo',
                 label: '',
                 title: 'Redo',
                 callback: function (cm) {
@@ -244,7 +244,7 @@ function initCodeworld() {
                 }
             },
             {
-                class: 'cw-button blue cw-button-copy',
+                class: 'cw-toolbar-button cw-button-copy',
                 label: '',
                 title: 'Copy',
                 callback: function (cm) {
@@ -253,7 +253,7 @@ function initCodeworld() {
                 }
             },
             {
-                class: 'cw-button blue cw-button-paste',
+                class: 'cw-toolbar-button cw-button-paste',
                 label: '',
                 title: 'Paste',
                 callback: function (cm) {
@@ -261,7 +261,7 @@ function initCodeworld() {
                 }
             },
             {
-                class: 'cw-button blue cw-button-cut',
+                class: 'cw-toolbar-button cw-button-cut',
                 label: '',
                 title: 'Cut',
                 callback: function (cm) {

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -55,6 +55,7 @@ async function init() {
     document.documentElement.classList.add(window.buildMode);
 
     window.cancelCompile = () => {};
+    window.clipboard = '';
 
     initCodeworld();
     registerStandardHints(() => {
@@ -208,7 +209,68 @@ function initCodeworld() {
                 }
             },
             async: true
-        }
+        },
+        buttons: [
+            {
+                class: 'cw-button blue cw-button-save',
+                label: '',
+                title: 'Save',
+                callback: function (cm) {
+                    saveProject();
+                }
+            },
+            {
+                class: 'cw-button blue cw-button-search',
+                label: '',
+                title: 'Search',
+                callback: function (cm) {
+                    cm.execCommand('find')
+                }
+            },
+            {
+                class: 'cw-button blue cw-button-undo',
+                label: '',
+                title: 'Undo',
+                callback: function (cm) {
+                    cm.undo();
+                }
+            },
+            {
+                class: 'cw-button blue cw-button-redo',
+                label: '',
+                title: 'Redo',
+                callback: function (cm) {
+                    cm.redo();
+                }
+            },
+            {
+                class: 'cw-button blue cw-button-copy',
+                label: '',
+                title: 'Copy',
+                callback: function (cm) {
+                    window.clipboard = cm.getSelection();
+                    document.execCommand('copy');
+                }
+            },
+            {
+                class: 'cw-button blue cw-button-paste',
+                label: '',
+                title: 'Paste',
+                callback: function (cm) {
+                    cm.replaceSelection(window.clipboard);
+                }
+            },
+            {
+                class: 'cw-button blue cw-button-cut',
+                label: '',
+                title: 'Cut',
+                callback: function (cm) {
+                    window.clipboard = cm.getSelection();
+                    document.execCommand('copy');
+                    cm.replaceSelection('');
+                }
+            }
+        ]
     });
     window.codeworldEditor.refresh();
     window.codeworldEditor.on('cursorActivity', () => {

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -116,6 +116,16 @@ const hintBlacklist = [
     'rose'
 ];
 
+function definePanelExtension () {
+    CodeMirror.defineExtension("addPanel", function(node) {
+        var originWrapper = this.getWrapperElement();
+        var wrapper = document.createElement("div");
+        originWrapper.parentNode.insertBefore(wrapper, originWrapper);
+        wrapper.appendChild(originWrapper);
+        wrapper.insertBefore(node, wrapper.firstChild);
+        });
+}
+
 // codeWorldSymbols is variable containing annotations and documentation
 // of builtin and user-defined variables.
 // Expected format:


### PR DESCRIPTION
closes #883

Previous attempt broke scrolling due to change editor position from `absolute` to `relative`. But just return to `absolute` and moving editor down was not enough, addons/display/panel.js (requirement for buttons.js) contain own resizing logic for editor field, which looks bad.

I threw away panel.js, and took from it only several lines we really need.