### PR TITLE
Removed leading / from baseURL, so that redirection works when CodeWo…

### DIFF
--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -559,7 +559,7 @@ compileIncrementally ctx mode programId = do
             let target = buildRootDir mode </> targetFile programId
             let result = buildRootDir mode </> resultFile programId
             let baseVer = buildRootDir mode </> baseVersionFile programId
-            let baseURL = "/runBaseJS?version=" ++ T.unpack ver
+            let baseURL = "runBaseJS?version=" ++ T.unpack ver
             let stage = UseBase target (baseSymbolFile ver) baseURL
 
             status <- compileSource stage source result (getMode mode) False


### PR DESCRIPTION
…rld route is not /
I tested a new version of CodeWorld in a separate server, and I used a route /newServer to redirect requests to this new server. The result was that the new server was really slow, and it often failed, returning just a blank screen. The problem is the incremental compiling requests were arriving to the old server, which was at /, and the program was being recompiled at the old server. This happened to work, because I was also sharing the filesystems with NFS, but when I disabled NFS, the new server just stopped working. I think removing the leading / from baseURL does not have any harmful effect, and it made the setting with the two servers work independently.
