### PR TITLE
correct documentation of 'dilated'

### DIFF
--- a/codeworld-api/src/CodeWorld/Picture.hs
+++ b/codeworld-api/src/CodeWorld/Picture.hs
@@ -316,7 +316,7 @@ translated = Translate (getDebugSrcLoc callStack)
 scaled :: HasCallStack => Double -> Double -> Picture -> Picture
 scaled = Scale (getDebugSrcLoc callStack)
 
--- | A picture scaled by these factors.
+-- | A picture scaled by this factor.
 dilated :: HasCallStack => Double -> Picture -> Picture
 dilated = Dilate (getDebugSrcLoc callStack)
 


### PR DESCRIPTION
The documentation for `dilated` currently reads:
```
A picture scaled by these factors.
```
The plural in there is strange, as `dilated` only takes one factor as argument. So the documentation should read:
```
A picture scaled by this factor.
```