### PR TITLE
Extras modules

### DIFF
--- a/codeworld-base/codeworld-base.cabal
+++ b/codeworld-base/codeworld-base.cabal
@@ -19,6 +19,8 @@ Library
   Hs-source-dirs:      src
   Js-sources:          jsbits/deep_eq.js
   Exposed-modules:     Prelude,
+                       Extras.Cw,
+                       Extras.Util,
                        Extras.Widget
   Other-modules:       Internal.Exports,
                        Internal.Num,

--- a/codeworld-base/src/Extras/Cw.hs
+++ b/codeworld-base/src/Extras/Cw.hs
@@ -1,0 +1,511 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PackageImports    #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-------------------------------------------------------------------------------
+-- | Additional entry points and graphical primitives for CodeWorld.
+--
+-- To use a function defined in this module, you must begin your code with this
+-- line:
+--
+-- > import Extras.Cw(function)
+--
+-- where instead of @function@ you write the actual name of the function you
+-- want to use.
+--
+-- You can specifiy more than one function. For example, if you want to use 3
+-- functions, then instead of writing 3 separate @import@ lines, you can write
+-- this:
+--
+-- > import Extras.Cw(function1,function2,function3)
+--
+-- All the functions defined in this module could be implemented directly
+-- in CodeWorld, as no internal features of the CodeWorld system are
+-- used in their implementation. These functions are provided to save
+-- you the tedium of having to add them to your code. To keep this module
+-- as small as possible, functions are added to this module only when
+-- it has been observed that several people keep adding variations of them
+-- to their respective codes.
+-- 
+
+module Extras.Cw(
+    -- * Animation convenience functions
+    between, beyond, saw
+    -- * Functions for accessing the points in a curve
+    , openCurvePoints, closedCurvePoints
+    -- * Color convenience functions
+    , rgb, withAlpha
+    -- * Layout
+    , pageFromTexts, grid, sprite, overlays, underlays
+    -- * New entry points
+    , slideshow, autoSlideshow
+    -- * Entry points with randomization
+    -- $randomIntro
+    , randomDrawingOf, randomAnimationOf, randomSlideshow, randomAutoSlideshow
+    ) where
+
+
+import Prelude
+import Extras.Util(lJustified)
+
+-------------------------------------------------------------------------------
+--- Top Level
+-------------------------------------------------------------------------------
+
+-- | A slide show of the given list of pictures with keyboard and mouse
+-- navigation. The following keys can be used to control the slide show:
+--
+--     * Restart the slide show: R
+--     * Go to the next slide: N, space bar, Enter, Page Down
+--     * Go to the previous slide: P, Backspace, Page Up
+--
+-- The given list of pictures must be finite. When the last slide is
+-- reached, the slide show will wrap, so that the first slide is shown
+-- next. This function cannot be used for showing undelimited step-motion
+-- animations.
+slideshow :: [Picture] -> Program
+slideshow(slides) = randomSlideshow(makeslides)
+    where
+    makeslides _ = slides
+
+-- | A slide show that automatically cycles through the list of given
+-- pictures. Each picture will be shown for the given number of seconds
+-- before advancing to the next picture.
+autoSlideshow :: ([Picture], Number) -> Program
+autoSlideshow(slides,period) = animationOf(sshow)
+  where
+  len = length(slides)
+  sshow(t)
+    | len < 1 = pictures([])
+    | otherwise = slides#num
+    where
+    num = 1 + remainder(truncation(t/period), len)
+
+-- $randomIntro
+-- All the randomized versions of entry points provided in this module use
+-- the same mechanism to handle random numbers. Before your code runs,
+-- the CodeWorld system generates a very large list of random numbers,
+-- which is passed to your code. For efficiency, the list is generated
+-- on demand, so that only those random numbers actually used in your code
+-- are generated. All the random numbers that the system generates are
+-- between 0 (included) and 1 (excluded).
+-- 
+-- Using the randomized versions is very simple.
+-- When you click on the output window, the drawing or animation that is
+-- currently being shown is replaced with a new one that uses different
+-- random numbers. You can keep clicking on your output to see different
+-- randomized outputs of your program.
+--
+-- When you write a program that uses the randomized versions,
+-- instead of providing a definition of a drawing, you
+-- must provide a definition of a function that takes in the list of
+-- random numbers as
+-- input and generates your drawing as output. Inside your function, you
+-- can use as many random numbers as you want.
+--
+
+
+-- | A randomized version of 'drawingOf'
+--
+-- Example:
+--
+-- > program = randomDrawingOf(draw)
+-- > draw(random) = solidRectangle(width,height)
+-- >     where
+-- >     width  = 1 + 9 * random#1
+-- >     height = 1 + 9 * random#2
+--
+-- The example above will show a different rectangle every time you click
+-- on the output. The width and the height will vary randomly between 1
+-- and 10 units.
+--
+randomDrawingOf :: ([Number] -> Picture) -> Program
+randomDrawingOf(makeDrawing) = interactionOf(initial,update,handle,draw)
+    where
+    initial rs = rs
+    update(model,_) = model
+    handle(r:rs,PointerPress(_)) = rs
+    handle(model,_) = model
+    draw(r:_) = makeDrawing(randomNumbers(r))
+
+-- | A randomized version of 'animationOf'
+--
+-- Example:
+-- 
+-- > program = randomAnimationOf(movie)
+-- > movie(random,t) = rotated(solidRectangle(width,height),45*t)
+-- >     where
+-- >     width  = 1 + 9 * random#1
+-- >     height = 1 + 9 * random#2
+--
+-- The example above will show a random rectangle that rotates around
+-- the origin. When you click on the output, a different random rectangle
+-- will be shown, which will also be rotating around the origin.
+--
+randomAnimationOf :: (([Number],Number) -> Picture) -> Program
+randomAnimationOf(movie) = interactionOf(initial,update,handle,draw)
+    where
+    initial (seed:rs) = (rs,0,seed)
+
+    update((rs,t,seed),dt) = (rs,t+dt,seed)
+
+    handle((rs,t,seed),PointerPress(_)) = (newrs,t,newseed)
+        where
+        newseed:newrs = randomNumbers(seed)
+    handle(model,_) = model
+
+    draw(rs,t,seed) = movie(rs,t)
+
+-- | A randomized version of 'slideshow'
+randomSlideshow :: ([Number] -> [Picture]) -> Program
+randomSlideshow = randomSlideshow_
+
+-- | A randomized version of 'autoSlideshow'
+randomAutoSlideshow :: ([Number] -> [Picture], Number) -> Program
+randomAutoSlideshow(mkslides,period) = simulationOf(initial,update,render)
+  where
+    initial (r:rs) = SS { time = 0, tlast = 0, current = 1, random = rs
+                        , slides = mkslides(randomNumbers(r))
+                        }
+
+    update(ss,dt) = update_wrap(update_current(update_time(ss,dt)))
+    
+    update_time(ss@SS{..},dt) = ss { time = time + dt }
+
+    update_current(ss@SS{..})
+        | time - tlast > period = ss { tlast = tlast + period
+                                     , current = current + 1
+                                     }
+        | otherwise = ss
+
+    update_wrap(ss@SS{..})
+        | current > length(slides) = ss { current = 1
+                                        , random = rs
+                                        , slides = mkslides(randomNumbers(r))
+                                        }
+        | otherwise = ss
+            where
+            r:rs = random
+            
+    render(SS{..}) = slides#current
+
+-------------------------------------------------------------------------------
+--- Top Level
+-------------------------------------------------------------------------------
+
+data SS = SS
+  { time :: Number
+  , tlast :: Number
+  , current :: Number
+  , random :: [Number]
+  , slides :: [Picture]
+  }
+  
+randomSlideshow_ :: ([Number] -> [Picture]) -> Program
+randomSlideshow_(mkslides) = interactionOf(initial,update,handle,render)
+    where
+    initial (r:rs) = SS { time = 0, tlast = 0, current = 1, random = rs
+                        , slides = mkslides(randomNumbers(r))
+                        }
+    update(ss@SS{..},dt) = ss { time = time + dt }
+    
+    render(SS{..})
+      | empty(slides) = pictures([])
+      | otherwise     = showSlide & slides#current
+      where
+      showSlide
+          | time - tlast > 2 = blank
+          | otherwise = translated(mark,-9.5,-9.5)
+                
+      mark = scaled(lettering(printed(current)),0.5,0.5)
+           & colored(solidRectangle(1,1),RGB(0.9,0.9,0.9))
+           
+    handle(ss,event) = mayHandleEvent(ss)
+      where
+      handleNav(c,s) = case event of
+          KeyPress "R" -> 1+length(s)
+          KeyPress "N" -> c+1
+          KeyPress " " ->  c+1
+          KeyPress "Enter" -> c+1
+          KeyPress "PageDown" -> c+1
+          KeyPress "P" -> c-1
+          KeyPress "PageUp" -> c-1
+          KeyPress "Backspace" -> c-1
+          PointerPress _ -> c+1
+          other -> c
+        
+      handlePan(c,s) = case event of
+          KeyPress "Left" -> over c moveleft s
+          KeyPress "Right" -> over c moveright s
+          KeyPress "Up" -> over c moveup s
+          KeyPress "Down" -> over c movedown s
+          KeyPress "A" -> over c moveleft s
+          KeyPress "D" -> over c moveright s
+          KeyPress "W" -> over c moveup s
+          KeyPress "S" -> over c movedown s
+          --KeyPress key -> (0,[messages [key]])
+          other -> s
+          where
+          moveleft(p)  = translated(p,-1, 0)
+          moveright(p) = translated(p, 1, 0)
+          moveup(p)    = translated(p, 0, 1)
+          movedown(p)  = translated(p, 0,-1)
+          over n f slides = [ if i == n then f s else s
+                            | s <- slides
+                            | i <- [1..]
+                            ]
+
+      mayHandleEvent(ss) = wrap(handleEvent(ss))
+          
+      handleEvent(ss@SS{..}) = ss
+          { current = nextCurrent
+          , tlast = time
+          , slides = handlePan(current,slides)
+          }
+          where
+          nextCurrent = handleNav(current,slides)
+          
+      remake(ss@SS{..}) = ss
+          { random = rs
+          , slides = mkslides(randomNumbers(r))
+          }
+          where
+          r:rs = random
+
+      realign(ss,newCurrent) = ss {current = newCurrent}
+      
+      wrap(ss@SS{..})
+          | current > nslides = wrap(realign(remake(ss),current-nslides))
+          | current < 1 = wrap(realign(remake(ss),current+nslides))
+          | otherwise = ss
+          where
+          nslides = length(slides)
+
+
+-------------------------------------------------------------------------------
+-- Animation Helpers
+-------------------------------------------------------------------------------
+
+-- | The expression @between(t,start,stop,drawing)@ will show
+-- the given @drawing@ when the time @t@ is between @start@ and @stop@
+between :: (Number,Number,Number,Picture) -> Picture
+between(t,start,stop,drawing) =
+  if t < start then blank
+  else if t < stop then drawing
+  else blank
+
+-- | The expression @beyond(t,start,drawing)@ will
+-- show the given @drawing@ when the time @t@ is beyond the @start@ time
+beyond :: (Number,Number,Picture) -> Picture
+beyond(t,start,drawing) =
+  if t < start then blank
+  else drawing
+
+-- | The expression @saw(t,p)@ is @0@
+-- when @t=0@, increases up to 1 when @t=p/2@, and then decreases back
+-- to 0 when @t=p@.
+-- This increasing and decreasing when @t@ goes from @0@ to @p@ is called
+-- an oscillation of period @p@. The oscillations will keep repeating,
+-- so that the function is @0@ when @t@ is @0,p,2p,3p,4p,5p,...@
+-- and it is 1 when @t@ is @p/2@, @3p/2@, @5p/2@, @7p/2@, @...@
+saw :: (Number,Number) -> Number
+saw(t,p) = 1 - abs(2*abs(remainder(t,p))/p - 1)
+
+------------------------------------------------------------------------------
+-- Curve interpolation 
+------------------------------------------------------------------------------
+
+-- | @openCurvePoints(controls,distance)@ is a list of points that approximate
+-- a curve passing through the given @controls@. A variable number of points
+-- is generated in such a way that the distance between them is approximately
+-- the given @distance@.
+openCurvePoints :: ([Point],Number) -> [Point]
+
+-- | This function is similar to 'openCurvePoints', but the points approximate
+-- a closed curve passing through the given controls.
+closedCurvePoints :: ([Point],Number) -> [Point]
+
+(openCurvePoints,closedCurvePoints) = (ocp,ccp)
+  where
+  -- 1D Linear interpolation
+  lerp1(a,b,t) = (1-t)*a + t*b
+
+  -- 2D Linear interpolation
+  lerp2((x0,y0),(x1,y1),t) = (lerp1(x0,x1,t),lerp1(y0,y1,t))
+
+  -- 2D Quadratic interpolation
+  qerp2(p0,p1,p2,t) = lerp2(lerp2(p0,p1,t),lerp2(p1,p2,t),t)
+
+  -- 2D Cubic interpolation
+  cerp2(p0,p1,p2,p3,t) = lerp2(qerp2(p0,p1,p2,t),qerp2(p1,p2,p3,t),t)
+
+  -- initial interpolation (p1,p2)
+  bezierFirst(p1,p2,p3,grain) =
+    let
+    c = vectorSum(p2,scaledVector(vectorDifference(p1,p3),r/2))
+    r = d12 / (d12 + d23)
+    d12 = dist(p1,p2)
+    d23 = dist(p2,p3)
+    l = 1 - grain / d12
+    in
+    [ qerp2(p1,c,p2,t) | t <- [0,grain..l] ]
+
+  -- final interpolation (p2,p3)
+  bezierLast(p1,p2,p3,grain) =
+    let
+    c = vectorSum(p2,scaledVector(vectorDifference(p3,p1),r/2))
+    r = d23 / (d12 + d23)
+    d12 = dist(p1,p2)
+    d23 = dist(p2,p3)
+    l = 1 - grain / d23
+    in
+    [ qerp2(p2,c,p3,t) | t <- [0,grain..l] ]
+
+  -- middle interpolation (p2,p3)
+  bezierMiddle(p1,p2,p3,p4,grain) =
+    let
+    c1 = vectorSum(p2,scaledVector(vectorDifference(p3,p1),r1/2))
+    c2 = vectorSum(p3,scaledVector(vectorDifference(p2,p4),r2/2))
+    r1 = d23 / (d12 + d23)
+    r2 = d23 / (d23 + d34)
+    d12 = dist(p1,p2)
+    d23 = dist(p2,p3)
+    d34 = dist(p3,p4)
+    l = 1 - grain / d23
+    in
+    [ cerp2(p2,c1,c2,p3,t) | t <- [0,grain..l] ]
+
+
+  ccp([],_) = []
+  ccp([p1],_) = []
+  ccp([p1,p2],_) = [p1,p2]
+  ccp(ps,grain) = go(last(ps,1) ++ ps ++ first(ps,2))
+    where
+    go(p1:p2:p3:p4:more) = bezierMiddle(p1,p2,p3,p4,grain) ++ go(p2:p3:p4:more)
+    go(_) = []
+
+  ocp([],_) = []
+  ocp([p1],_) = []
+  ocp([p1,p2],_) = [p1,p2]
+  ocp(p1:p2:p3:more,grain) = bezierFirst(p1,p2,p3,grain) ++ go(p1:p2:p3:more)
+    where
+    go(p1:p2:p3:p4:more) = bezierMiddle(p1,p2,p3,p4,grain) ++ go(p2:p3:p4:more)
+    go([p1,p2,p3]) = bezierLast(p1,p2,p3,grain)
+    go(_) = []
+
+  dist(p,q) = vectorLength(vectorDifference(p,q))
+
+
+-------------------------------------------------------------------------------
+-- Colors
+-------------------------------------------------------------------------------
+
+-- | This function allows you to specify color components in the range 0 to 255
+-- instead of 0 to 1.
+rgb :: (Number,Number,Number) -> Color
+rgb(r,g,b) = RGB(r/256,g/256,b/256) -- Not exact, but colors aren't anyway...
+
+-- | This function allows you to specify the level of transparency of the
+-- given color. Transparency must be given in the range 0 (fully transparent)
+-- to 1 (fully opaque).
+withAlpha :: (Color,Number) -> Color
+withAlpha(RGBA(r,g,b,_),a) = RGBA(r,g,b,a)
+
+-------------------------------------------------------------------------------
+--- Layout
+-------------------------------------------------------------------------------
+
+-- | A picture that represents the given list of texts, so that each
+-- text in the list is shown in a separate line. Lines start at the
+-- top left corner of the output window and grow downward.
+-- Each line of text can fit 66 characters, and 40 lines can fit
+-- in a single page. The lettering is shown in monospaced font.
+pageFromTexts :: [Text] -> Picture
+pageFromTexts(lines) = pictures([showline(i) | i <- [1..n]])
+    where
+    n = length(lines)
+    showline(i) = translated(scaled(fmt(lines#i),0.5,0.5),0,10.25-0.5*i)
+    -- Output should be 40 rows and 66 columns
+    fmt(txt) = styledLettering(lJustified(txt,66),Monospace,Italic)
+
+-- | A @grid(cell,rows,columns)@ is a grid with the given number of @rows@ and
+-- @columns@, where the rows are numbered top to bottom (top row is row 1)
+-- and the columns are numbered left to right (leftmost column is column 1).
+-- The user needs to specify what to draw at each cell in the grid. The given
+-- function @cell@ should specify a 20 by 20 picture for each row and column,
+-- where the first argument is the row number, and the second argument is the
+-- column number:
+-- 
+-- > cell(row,col) = fullSizePicture
+--
+-- Each full size picture will be scaled to fit within the corresponding cell.
+-- Look at the example in the documentation of 'sprite' to see how to use it.
+--
+grid :: ((Number,Number) -> Picture,Number,Number) -> Picture
+grid(cell,rows,cols) = translated(pictures(rpic),-10,10)
+  where
+  w = 20/cols
+  h = 20/rows
+  transform(row,col) = translated(base,w*(col-1/2),-h*(row-1/2))
+    where
+    base = scaled(cell(row,col),1/cols,1/rows)
+  rpic = [ transform(row,col) | row <- [1..rows], col <- [1..cols] ]
+
+-- | A @sprite(picture,rows,columns)@ creates a function that can be used to
+-- place the given @picture@ of a sprite into a grid with the given
+-- number of @rows@ and @columns@. The created function needs two
+-- arguments: the row and the column at which you want to show the sprite.
+-- The picture of the sprite should be a full size picture (20x20), which
+-- will be scaled to fit the corresponding cell in the grid.
+--
+-- 
+-- Example:
+--
+-- > import Extras.Cw(saw,grid,sprite)
+-- > import Extras.Util(printedPoint)
+-- > 
+-- > program = animationOf(movie)
+-- > 
+-- > movie(t) = sprite1(row,col) & background
+-- >   where
+-- >   -- Jump between rows 1 and 10 every 100 seconds
+-- >   row = 1 + truncation(10*saw(t,100))
+-- >   -- Move smoothly between cols 1 and 10 every 10 seconds
+-- >   col = 1 + 9*saw(t,10)
+-- > 
+-- > sprite1 = sprite(pic,10,10)
+-- >   where
+-- >   pic = rotated(eks,45)
+-- >   eks = solidRectangle(10,1) & solidRectangle(1,10)
+-- > 
+-- > background = grid(cell,10,10)
+-- >     where
+-- >     cell(row,col) = dilated(lettering(printedPoint(row,col)),5)
+-- >                   & rectangle(19,19)
+--
+sprite :: (Picture,Number,Number) -> (Number,Number) -> Picture
+sprite(pic,rows,cols) = transform
+  where
+  w = 20/cols
+  h = 20/rows
+  dw = w/2 + 10
+  dh = h/2 + 10
+  base = scaled(pic,1/cols,1/rows)
+  transform(row,col) = translated(base,w*col-dw,-h*row+dh)
+
+-- | @overlays(fig,n)@ is a shortcut for @fig(1) & fig(2) & ... & fig(n)@
+overlays :: ((Number -> Picture),Number) -> Picture
+overlays(f,n) = overlays'(f,max(0,truncation(n)))
+    where
+    overlays'(f,0) = blank
+    overlays'(f,n) = overlays'(f,n-1) & f(n)
+
+-- | @underlays(fig,n)@ is a shortcut for @fig(n) & fig(n-1) & ... & fig(1)@
+underlays :: ((Number -> Picture),Number) -> Picture
+underlays(f,n) = underlays'(f,max(0,truncation(n)))
+    where
+    underlays'(f,0) = blank
+    underlays'(f,n) = f(n) & underlays'(f,n-1)

--- a/codeworld-base/src/Extras/Util.hs
+++ b/codeworld-base/src/Extras/Util.hs
@@ -1,0 +1,442 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PackageImports    #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-------------------------------------------------------------------------------
+-- | A set of functions and variables that provide additional support for your
+-- programs.
+--
+-- To use a function defined in this module, you must begin your code with this
+-- line:
+--
+-- > import Extras.Util(function)
+--
+-- where instead of @function@ you write the actual name of the function you
+-- want to use.
+--
+-- You can specifiy more than one function. For example, if you want to use 3
+-- functions, then instead of writing 3 separate @import@ lines, you can write
+-- this:
+--
+-- > import Extras.Util(function1,function2,function3)
+--
+
+module Extras.Util(
+    -- * Predicates
+    Predicate, precedes, is_in, nonEmpty, selected, selectedValues
+    -- * Grouping and Sorting lists
+    , logicalGroupBy, alphabeticalGroupBy, numericalGroupBy
+    , alphabeticalSortedOn, numericalSortedOn
+    -- * Control flow
+    , run, recur, repeat, recurWhile, repeatWhile
+    , iterated, foreach, forloop
+    -- * List manipulation
+    , prepend, append, list, listn, pairs, unpairs, zipped, unzipped
+    , indexOf
+    -- * Text formatting
+    , lJustified, rJustified
+    , printedDecimals, printedNumbers, printedPoint
+    -- * Other useful functions
+    , cumulativeSums
+    , itself
+    , textHash
+    ) where
+
+import Prelude
+import qualified Data.List as L
+import Internal.Text(fromCWText,toCWText)
+import qualified "base" Prelude as P
+import           "base" Prelude ((.))
+
+-------------------------------------------------------------------------------
+-- Predicates
+-------------------------------------------------------------------------------
+
+-- | A predicate is a function that separates all possible values of a given
+-- type @t@ into two groups: those for which the predicate is @True@ and those
+-- for which the predicate is @False@ when it is applied to them.
+type Predicate t = t -> Truth
+
+-- | @precedes(text1,text2)@ is @True@ whenever @text1@ precedes @text2@
+-- alphabetically. It is @False@ otherwise.
+-- When the two texts are the same,
+-- the result of @precedes@ is @False@.
+precedes :: Predicate(Text,Text)
+precedes(a,b) = fromCWText a P.< fromCWText b
+
+-- | A predicate that can be applied to an argument to check whether
+-- it is contained in the given @list@.
+--
+-- Example:
+--
+-- > selected([1..10],is_in([0,2..100]) -- is [2,4,6,8,10]
+--
+is_in :: [value] -> Predicate value
+is_in(list)(x) = contains(list,x)
+
+-- | A predicate that is @True@ when the argument is a non-empty list.
+nonEmpty :: Predicate [value]
+nonEmpty = not.empty
+
+-- | A list of values selected from the given list. A value
+-- is selected if it satisfies the given predicate. Otherwise, it is discarded.
+selected :: ([value], Predicate value) -> [value]
+selected(ls,f) = P.filter f ls
+
+-- | A list of values selected form the given key-value list. A value
+-- is selected if the corresponding key satisfies the given predicate.
+selectedValues :: ([(key,value)], Predicate key) -> [value]
+selectedValues(kvList, pred) = [ v | (k,v) <- kvList, pred(k) ]
+
+-------------------------------------------------------------------------------
+-- Grouping and Sorting
+-------------------------------------------------------------------------------
+
+-- | @alphabeticalSortedOn(key, list)@ is a list that has the same values as
+-- the given @list@, but the values are sorted in the
+-- following way: if @key(value1)@ precedes @key(value2)@ alphabetically
+-- then @value1@ will apear before @value2@
+alphabeticalSortedOn :: (value -> Text, [value]) -> [value]
+alphabeticalSortedOn(k,l) = L.sortOn (fromCWText . k) l
+
+-- | @numericalSortedOn(key, list)@ is a list that has the same values as the
+-- given @list@, but the values are sorted in the following
+-- way: if @key(value1) < key(value2)@ then @value1@ will apear before
+-- @value2@
+numericalSortedOn :: (value -> Number, [value]) -> [value]
+numericalSortedOn(k,l) = L.sortOn k l
+
+-- |@logicalGroupBy(predicate, list)@ breaks up the given @list@ into
+-- two sublists: one with the elements that satisfy the given @predicate@
+-- and another with the elements that do not satisfy the given @predicate@.
+-- Neither the order of the elements in each
+-- sublist nor the order of each sublist in the output list is specified,
+-- so you cannot make any assumption about the order in which elements
+-- will be present in the result.
+--
+-- Example:
+--
+-- > logicalGroupBy(even, [1,2,3,4]) -- is [ (True,[2,4]), (False,[1,3]) ]
+--
+logicalGroupBy :: (Predicate value, [value]) -> [ (Truth,[value]) ]
+logicalGroupBy(pred,list) = [ (True,yes), (False,no) ]
+    where
+    (yes,no) = L.partition pred list
+
+-- |@alphabeticalGroupBy(key, list)@ breaks up the given @list@ into sublists
+-- that have the same @key@.
+-- Neither the order of the elements in each
+-- sublist nor the order of each sublist in the output list is specified,
+-- so you cannot make any assumption about the order in which elements
+-- will be present in the output list.
+--
+alphabeticalGroupBy :: (value -> Text, [value]) -> [(Text,[value])]
+alphabeticalGroupBy(key, list) = apply(list)
+    where
+    apply = groupBy . aSortOn P.fst . P.map build
+    aSortOn(p)(x) = alphabeticalSortedOn(p,x)
+    build x = (key x,x)
+
+-- |@numericalGroupBy(key, list)@ breaks up the given @list@ into sublists
+-- that have the same @key@.
+-- Neither the order of the elements in each
+-- sublist nor the order of each sublist in the output list is specified,
+-- so you cannot make any assumption about the order in which elements
+-- will be present in the output list.
+--
+numericalGroupBy :: (value -> Number, [value]) -> [(Number,[value])]
+numericalGroupBy(key, list) = apply(list)
+    where
+    apply = groupBy . nSortOn P.fst . P.map build
+    nSortOn(p)(x) = numericalSortedOn(p,x)
+    build x = (key x,x)
+
+-- Not exported
+groupBy :: [(a,b)] -> [(a,[b])]
+groupBy [] = []
+groupBy ((x,d):xds) = (x,d:ds) : groupBy xds_ne
+    where
+    (xds_eq,xds_ne) = L.span ((x ==) . P.fst) xds
+    ds = P.map P.snd xds_eq
+
+-------------------------------------------------------------------------------
+--- Control flow
+-------------------------------------------------------------------------------
+
+-- | Run a sequence of transformations in order on the given initial state.
+-- For example, the expression @run([f1,f2,f3])(x)@
+-- is the same as @f3(f2(f1(x)))@
+run :: [value -> value] -> value -> value
+run([])(x) = x
+run(f:fs)(x) = run(fs)(f(x))
+
+-- | Repeat a transformation the given number of times.
+-- For example, the expression @recur(3,f)(x)@ is the same as @f(f(f(x)))@
+recur :: (Number,value -> value) -> value -> value
+recur(0,f)(x) = x
+recur(n,f)(x) = recur(n-1,f)(f(x))
+
+-- | Repeat a sequence of transformations a given number of times
+repeat :: (Number,[value -> value]) -> value -> value
+repeat(n,fs) = recur(n,run(fs))
+
+-- | Keep repeating a transformation while the given predicate is True.
+-- The result is the first value that does not satisfy the predicate.
+recurWhile :: (Predicate value, value -> value) -> value -> value
+recurWhile(cond,f)(x) = if cond x then recurWhile(cond,f)(f x) else x
+
+-- | Keep repeating a sequence of transformations while
+-- the given predicate is True
+-- The result is the first value that does not satisfy the predicate.
+repeatWhile :: (Predicate value, [value -> value]) -> value -> value
+repeatWhile(cond,fs)(x) = loop (repeating fs) x
+    where
+    loop [] x = x
+    loop (f:fs) x = if cond x then loop fs (f x) else x
+
+-- | Constructs a list by applying a function
+-- to all the elements of a given list
+foreach :: ([input],input -> output) -> [output]
+foreach(l,f) = P.map f l
+
+-- | Creates the list @[a,f(a),f(f(a)),f(f(f(a))),...]@,
+-- where @a@ is the given value and @f@ is the given function.
+iterated :: ((value -> value), value) -> [value]
+iterated(f,a) = a : iterated(f,f(a))
+
+-- | @forloop(initial,check,next,output)@ produces a list of outputs,
+-- where each output is generated by repeatedly applying @output@
+-- to the current @state@, whose value changes after each iteration
+-- of the loop. The @state@ is initially set to the value given by
+-- @initial@, and new states are generated from it by applying
+-- @next@ to the current @state@.
+-- The whole process continues for as long as the current @state@
+-- satisfies the predicate given by @check@.
+--
+-- For example, the following code will produce [0,0,6,6,12,12,20,20]:
+--
+-- > forloop(init,check,next,output)
+-- >     where
+-- >     init = (1,0)
+-- >     check(n,sum) = n <= 10
+-- >     next(n,sum) = (n+1,if even(n) then sum+n else sum)
+-- >     output(n,sum) = sum
+--
+-- = Using forloop to implement other iteration functions
+--
+-- Basically, any iteration function can be used to implement the rest.
+-- A few examples of implementations based on @forloop@ follow.
+--
+-- @iterated@:
+--
+-- > iterated(f,a) = forloop(a,\x -> True,f,\x -> x)
+--
+-- @foreach@:
+--
+-- > foreach(list,f) = forloop(list,nonEmpty,\l -> rest(l,1),l#1)
+--
+-- @recurWhile@:
+--
+-- > recurWhile(cond,f)(v) = last(v:forloop(init,check,next,output),1)#1
+-- >     where
+-- >     init         = (x,f(x))
+-- >     check (x, _) = cond(x)
+-- >     next  (_,fx) = (fx,f(fx))
+-- >     output(_,fx) = fx
+--
+forloop :: (state, Predicate state, state -> state, state -> output)
+        -> [output]
+forloop(init,check,next,output)
+  | check(init) = output(init) : forloop(next(init),check,next,output)
+  | otherwise = []
+
+
+-------------------------------------------------------------------------------
+-- List manipulation
+-------------------------------------------------------------------------------
+
+-- | Add a value to the front of a list
+prepend :: (value, [value]) -> [value]
+prepend(x, xs) = x : xs
+
+-- | Add a value at the end of a list
+append :: (value, [value]) -> [value]
+append(x,xs) = xs ++ [x]
+
+-- | Converts a given function @f@ into a list @[f(1),f(2),f(3),...]@
+list :: (Number -> value) -> [value]
+list(f) = [f(i) | i <- [1..]]
+
+-- | Converts a given function @f@ into a finite
+-- list @[f(1),f(2),f(3),...,f(n)]@,
+-- where @n@ is the given number.
+listn :: (Number -> value, Number) -> [value]
+listn(f,n) = [f(i) | i <- [1..n]]
+
+-- | A list of pairs that is created by
+-- putting together each consecutive pair of values in the given
+-- list. Single elements at the end of the list are discarded.
+--
+-- Example:
+--
+-- > pairs([1..9]) -- is [(1,2),(3,4),(5,6),(7,8)]
+--
+pairs :: [value] -> [(value,value)]
+pairs (x:y:rs) = (x,y) : pairs(rs)
+pairs _ = []
+
+-- | A list of values obtained by flattening the given
+-- list of pairs, so that the overall order of the values
+-- is preserved.
+unpairs :: [(value,value)] -> [value]
+unpairs [] = []
+unpairs ((x,y):xys) = x : y : unpairs xys
+    
+-- | A pair of lists obtained by separating each pair
+-- from the given list of pairs.
+unzipped :: [(a,b)] -> ([a],[b])
+unzipped [] = ([],[])
+unzipped ((x,y):xys) = (x:xs,y:ys)
+    where
+    (xs,ys) = unzipped xys
+    
+-- | A list of pairs that results from blending the
+-- given pair of lists, by taking one value from
+-- each list at a time. The resulting list is as
+-- short as the shortest of the two given lists.
+-- When one of the lists is longer than the other,
+-- the extra values will be discarded.
+zipped :: ([a],[b]) -> [(a,b)]
+zipped(a:as,b:bs) = (a,b) : zipped(as,bs)
+zipped _ = []
+
+-- | Either the index of the first occurrence of the given value within
+-- the given list, or 0 if the value does not occur in the list. List
+-- indices start at 1.
+indexOf :: (value,[value]) -> Number
+indexOf(element,list) = indexOf_(1,list)
+  where
+  indexOf_(_,[]) = 0
+  indexOf_(i,x:xs)
+    | element == x = i
+    | otherwise = indexOf_(i+1,xs)
+
+-------------------------------------------------------------------------------
+-- Text formatting
+-------------------------------------------------------------------------------
+
+-- | Justifies text to the left, and adds padding on the right, so that the
+-- text occupies exactly the given width. Justification works best
+-- with lettering based on monospaced fonts.
+lJustified :: (Text,Number) -> Text
+lJustified(txt,width)
+  | len < width = lJustified(txt <> " ",width)
+  | len > width = cut
+  | otherwise = joined(last(characters(txt),width))
+  where
+  len = numberOfCharacters(txt)
+  cut = joined(first(characters(txt),width))
+  
+-- | Justifies text to the right, and adds padding on the left, so that the
+-- text occupies exactly the given width. Justification works best
+-- with lettering based on monospaced fonts.
+rJustified :: (Text,Number) -> Text
+rJustified(txt,width)
+  | len < width = rJustified(" " <> txt,width)
+  | len > width = cut
+  | otherwise = joined(last(characters(txt),width))
+  where
+  len = numberOfCharacters(txt)
+  cut = joined(last(characters(txt),width))
+  
+-- | A text representation of the given number, so that it has
+-- exactly the given number of decimals. This means that the output
+-- does not represent the given number exactly, but a number that is only
+-- approximately equal to the given number. When the number of decimals
+-- requested is 1 or more, a decimal point is also included in the text
+-- representation, followed or preceded by 0 if necessary.
+printedDecimals :: (Number,Number) -> Text
+printedDecimals(number,prec)
+    | number < 0 = "-" <> printedDecimals(-number,prec)
+    | prec <= 0 = printed(rounded(number))
+    | otherwise = joined(go(characters(printed(rounded(number*10^prec)))))
+    where
+    go(n) | len > prec = first(n,len-prec) ++ ("." : last(n,prec))
+          | otherwise = "0" : "." : fill(prec-len,n)
+          where
+          len = length(n)
+          fill(0,txt) = txt
+          fill(num,txt) = "0" : fill(num-1,txt)
+                                                                       
+-- | A text representation of the given list of numbers.
+printedNumbers :: [Number] -> Text
+printedNumbers(list) = "[" <> printedRawNumbers(list) <> "]"
+  where
+  printedRawNumbers[] = ""
+  printedRawNumbers[n] = printed(n)
+  printedRawNumbers(n:ns) = printed(n) <> ", " <> printedRawNumbers(ns)
+
+-- | A text representation of the given point.
+printedPoint :: Point -> Text
+printedPoint(x,y) = "(" <> printed(x) <> "," <> printed(y) <> ")"
+
+-------------------------------------------------------------------------------
+-- Other
+-------------------------------------------------------------------------------
+
+-- | A list of cumulative sums calculated from the given list.
+--
+-- > cumulativeSums([1,2,3,4]) -- is [1,1+2,1+2+3,1+2+3+4]
+--
+-- Note that @cumulativeSums@ could be implemented using @forloop@ as follows:
+--
+-- > cumulativeSums(list) = forloop(init,check,next,output)
+-- >     where
+-- >     init   =                       (list,0)
+-- >     check  = \(list,currentSum) -> nonEmpty(list)
+-- >     next   = \(list,currentSum) -> (rest(list,1),currentSum + list#1)
+-- >     output = \(list,currentSum) -> currentSum
+--
+cumulativeSums :: [Number] -> [Number]
+cumulativeSums = P.tail . P.scanl (+) 0
+
+-- | A function that passes the input unchanged as output. It is useful to
+-- indicate a transformation that /does nothing/ for those operations
+-- where a transformation is expected.
+itself :: value -> value
+itself = P.id
+
+-- | Creates a number out of a text in such a way
+-- that 
+--
+-- (1) it is difficult to predict the number
+-- corresponding to a given text, and
+-- (2) it is
+-- relatively unlikely that two similar texts
+-- have similar numbers.
+--
+textHash :: Text -> Number
+textHash(s) = go h0 (characters s)
+  where
+  a = 33
+  h0 = 5381
+  p = 1001
+  go h [] = h
+  go h (r:rs) = 
+    let h' = remainder(h*a+lookup(r),p)
+    in go h' rs
+
+  lookup c = go' 0 chars
+    where
+    go' i [] = i
+    go' i (r:rs) | c == r = i
+                 | otherwise = go' (i+1) rs
+
+  chars = characters(lower<>upper<>other)
+    where
+    lower = "abcdefghijklmnopqrstuvxyz"
+    upper = uppercase(lower)
+    other = " .,'!@#$%^&*()-=_+|/<>\\"

--- a/web/help/codeworld.shelf
+++ b/web/help/codeworld.shelf
@@ -15,8 +15,8 @@
     "Appendix: Editor":    "help/editor.md",
     "Appendix: Examples":  "help/examples.md",
     "Appendix: Reference": "doc/Prelude.html",
-    "Appendix: Reference (Extras.Cw)": "doc/Extras-Cw.html"
-    "Appendix: Reference (Extras.Util)": "doc/Extras-Util.html"
+    "Appendix: Reference (Extras.Cw)": "doc/Extras-Cw.html",
+    "Appendix: Reference (Extras.Util)": "doc/Extras-Util.html",
     "Appendix: Reference (Extras.Widget)": "doc/Extras-Widget.html"
   }
 }

--- a/web/help/codeworld.shelf
+++ b/web/help/codeworld.shelf
@@ -15,6 +15,8 @@
     "Appendix: Editor":    "help/editor.md",
     "Appendix: Examples":  "help/examples.md",
     "Appendix: Reference": "doc/Prelude.html",
+    "Appendix: Reference (Extras.Cw)": "doc/Extras-Cw.html"
+    "Appendix: Reference (Extras.Util)": "doc/Extras-Util.html"
     "Appendix: Reference (Extras.Widget)": "doc/Extras-Widget.html"
   }
 }


### PR DESCRIPTION
These are a selection of the functions I have in my Extras module. I cleaned them up and chose those that are actually used in other places.

The `recur` and `repeat` functions in Extras.Util may seem redundant, but I need them for other modules. In particular, `repeat` is used in the Turtle graphics module (to be submitted soon), and I wanted to keep it compatible with the way Logo uses it, so that Logo programs are easy to transfer. However, the function that makes sense to me is `recur`, so I wanted to include that too.

I wrote the `forloop` function to address critics who told me that after a year of doing CodeWorld, students do not even know how to do for loops. List comprehensions are not perceived to be the
same thing as *step-by-step* for loops. Surprisingly, it seems that `forloop` is easier to understand than  
`fold` or `reduce`.
