### PR TITLE
Graphed now takes two separate scaling factors

### DIFF
--- a/codeworld-base/src/Extras/Cw.hs
+++ b/codeworld-base/src/Extras/Cw.hs
@@ -549,7 +549,7 @@ underlays(f,n) = underlays'(f,max(0,truncation(n)))
 --
 -- Example 1 shows a circle that grows forever, while the graph keeps
 -- adjusting the scale so that it fits within the output.
--- Example 2 shows a graph with 100 circles. It used the function
+-- Example 2 shows a graph with 100 circles. It uses the function
 -- 'guiDrawingOf' from "Extras.Widget".
 --
 graphed :: (Picture,Number) -> Picture
@@ -572,21 +572,21 @@ graph(maxnum) = labels & axes & rotated(axes,90)
   minorAxis(x) = colored(axis(x),g(0.1,0.2))
   g(s,a) = RGBA(s,s,s,a)
 
-  p(x) | x < 1000000 = translated(lunj( x), p,-1/2)
-                     & translated(lunj(-x),-p,-1/2)
-       | 3 <= p && p < 6 = translated(lunj( x), p,-1/2)
-                         & translated(lunj(-x),-p,-1/2)
+  p(x) | x < 1000000 = translated(lunj( x), pos,-1/2)
+                     & translated(lunj(-x),-pos,-1/2)
+       | 3 <= pos && pos < 6 = translated(lunj( x), pos,-1/2)
+                             & translated(lunj(-x),-pos,-1/2)
        | otherwise = blank
        where
-       p = x * scaling
+       pos = x * scaling
 
-  q(y) | y < 50000 = translated(ljust( y),-1, p)
-                   & translated(ljust(-y),-1,-p)
-       | 3 <= p && p < 6 = translated(lunj( y),-1, p)
-                         & translated(lunj(-y),-1,-p)
+  q(y) | y < 50000 = translated(ljust( y),-1, pos)
+                   & translated(ljust(-y),-1,-pos)
+       | 3 <= pos && pos < 6 = translated(lunj( y),-1, pos)
+                             & translated(lunj(-y),-1,-pos)
        | otherwise = blank
        where
-       p = y * scaling
+       pos = y * scaling
 
   lunj(v)  = dilated(styledLettering(printed(v),Monospace,Plain),0.5)
   ljust(v) = dilated(styledLettering( rJustified(printed(v),5)


### PR DESCRIPTION
When I showed the new graphed function to the teacher, she immediately requested being able to specify the X and Y scales separately. So, I changed graphed to accommodate that. This is an incompatible change, but nobody should be using it yet, so I guess it is OK.

While I was at it, I also implemented wideGraphed as a proof of concept. I don't want to step on anybody's toes, but I would be happy to go ahead and implement wideCoordinatePlane if you want.

Here is a link to the code that the teacher did immediately after I provided her with the interface:

https://blackeyepeas.phys.lsu.edu/cwn/#Pf93EdrftpZNnpiWXJi4BBQ

