### PR TITLE
Wide aspect (note: this is not an Extras PR)

### DIFF
--- a/web/css/runner.css
+++ b/web/css/runner.css
@@ -6,9 +6,9 @@
 #screen {
     cursor: default;
     width: 100vw;
-    height: 100vw;
-    max-height: 100vh;
-    max-width: 100vh;
+    height: 100vh;
+    /* max-height: 100vh; */
+    /* max-width: 100vh; */
 }
 
 #infobox {


### PR DESCRIPTION
I just realized that a small change in the CSS file is all that is needed for having outputs with variable aspect ratios in fullscreen mode (i.e., with links generated by *share without code*). The output fills the browser window as much as possible: When the window is longer in the horizontal direction, the height stays fixed at 20 units while the width adjusts to the size. When the window is longer in the vertical direction, the width stays fixed at 20 units while the height adjusts to the available size. I think this is the behavior you described in #938, which is OK. I would have preferred the height to always stay fixed at 20 units, but I guess this works too.
In normal mode, there is no noticeable difference when using 20x20 drawings. If you have a wider drawing, you can only see the central 20x20 portion, but you can pan and zoom to see the rest.
Maybe there is some use case that I missed, but I tested it with several browsers and could not find anything that did not work the same as before, except that in fullscreen mode I can have wider outputs.
I also added a function named `squareFrame`  in `Extras.Cw` as a poor man's clipping, so that regions outside the standard 20x20 can be covered, in case someone wants to emulate the fixed-aspect-ratio behavior in fullscreen mode.