### PR TITLE
Fixed bug in the URL generated by Share without code when the server is not at /

### DIFF
--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -1087,7 +1087,7 @@ function share() {
             const a = document.createElement('a');
             a.href = window.location.href;
             a.hash = '';
-            a.pathname = '/run.html';
+            a.pathname = window.location.pathname + 'run.html';
             a.search = `?mode=${window.buildMode}&dhash=${window.deployHash}`;
 
             url = a.href;


### PR DESCRIPTION
This PR is not for Extras. It fixes the generated URL to add the correct pathname for *Share without code*.

