### PR TITLE
Bugfix in Driver.hs

### DIFF
--- a/codeworld-api/src/CodeWorld/Driver.hs
+++ b/codeworld-api/src/CodeWorld/Driver.hs
@@ -1164,9 +1164,13 @@ getMousePos canvas = do
         cx <- ClientRect.getLeft rect
         cy <- ClientRect.getTop rect
         cw <- ClientRect.getWidth rect
+        ch <- ClientRect.getHeight rect
+        let cs = min cw ch / 2
+        let mx = round (cx + cw / 2)
+        let my = round (cy + ch / 2)
         return
-            ( 20 * fromIntegral (ix - round cx) / realToFrac cw - 10
-            , 20 * fromIntegral (round cy - iy) / realToFrac cw + 10)
+            ( 10 * fromIntegral (ix - mx) / realToFrac cs
+            , 10 * fromIntegral (my - iy) / realToFrac cs)
 
 onEvents :: Element -> (Event -> IO ()) -> IO ()
 onEvents canvas handler = do

--- a/codeworld-base/src/Extras/Colors.hs
+++ b/codeworld-base/src/Extras/Colors.hs
@@ -34,8 +34,8 @@ painted(pic,name) = colored(pic,colorNamed(name))
 rgb :: (Number,Number,Number) -> Color
 rgb(r,g,b) = RGB(r/255,g/255,b/255)
 
--- | A shade of grey as given by the argument, where @grey(0)@ is @black@
--- and @grey(1)@ is white.
+-- | A shade of grey as given by the argument, where @greyed(0)@ is @black@
+-- and @greyed(1)@ is white.
 greyed :: Number -> Color
 greyed(g) = RGB(g,g,g)
 


### PR DESCRIPTION
I adjusted getMouse (for GHCJS) so that it works with arbitrary aspects. Otherwise, the previous change in the CSS file made the fullscreen mode return the wrong mouse location. 

I did not change the blank canvas getMouse because I do not know how that works and did not have time to set up a testing environment for it.
