### PR TITLE
Two new requirements rules - line length and no warnings

### DIFF
--- a/RequirementChecker.md
+++ b/RequirementChecker.md
@@ -219,6 +219,26 @@ of conditions. Here are the current checks implemented.
 
   Checks that there are no references to `var` in the module.
 
+- `lineLength`
+
+  Example:
+
+      lineLength: 80
+  
+  Checks that there are no lines longer than 80 characters.
+
+-  `noWarnings`
+
+  Example:
+
+      noWarnings:
+        strict: false
+        exceptions: Defined but not used
+
+  If `strict` is true, checks that there are no warnings in the module.
+  If `strict` is false, checks that there are no warnings except for those 
+  matching a regular expression given by `exceptions`.
+
 This is by no means intended to be the full constraint language;
 rather, it is a small set of a few requirements that can be used for
 testing.  The language is strongly subject to change in the future.
@@ -243,10 +263,8 @@ The following use cases have been proposed, but are not yet implemented.
   include allowing something to be repeated (so a function definition
   could have an arbitrary number of arguments or guards), etc.
 
-- Style constraints.  e.g., all top-level definitions must have type
-  declarations.  Or all lines must be 80 characters or less.
-
-- No warnings.  Alternatively, no warnings of specific types.
+- Other style constraints.  e.g., all top-level definitions must have type
+  declarations.
 
 - Forbidden imported symbols or modules.  By whitelist or blacklist.
   Exceptions should be allowed for specific definitions (usually

--- a/RequirementChecker.md
+++ b/RequirementChecker.md
@@ -219,25 +219,23 @@ of conditions. Here are the current checks implemented.
 
   Checks that there are no references to `var` in the module.
 
-- `lineLength`
+- `maxLineLength`
 
   Example:
 
-      lineLength: 80
+      maxLineLength: 80
   
   Checks that there are no lines longer than 80 characters.
 
--  `noWarnings`
+-  `noWarningsExcept`
 
   Example:
 
-      noWarnings:
-        strict: false
-        exceptions: Defined but not used
+      noWarningsExcept: [Defined but not used]
 
-  If `strict` is true, checks that there are no warnings in the module.
-  If `strict` is false, checks that there are no warnings except for those 
-  matching a regular expression given by `exceptions`.
+  Checks that there are no warnings, except for those that match any of a 
+  list of given regular expressions. This list can be empty, in which case
+  no warnings will be allowed.
 
 This is by no means intended to be the full constraint language;
 rather, it is a small set of a few requirements that can be used for

--- a/codeworld-compiler/src/CodeWorld/Compile/Framework.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Framework.hs
@@ -109,6 +109,11 @@ getParsedCode = do
             modify $ \state -> state { compileParsedSource = Just parsed }
             return parsed
 
+getDiagnostics :: MonadCompile m => m [Diagnostic]
+getDiagnostics = do
+    diags <- gets compileErrors
+    return diags
+
 codeworldModeExts :: [String]
 codeworldModeExts =
     [ "BangPatterns"

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
@@ -215,6 +215,14 @@ checkRule (LineLength len) = do
             failure $ "One or more lines longer than " ++ show len ++ " characters."
        | otherwise -> success
 
+checkRule (NoWarnings b pat) = do
+    diags <- getDiagnostics
+    let warns = if b then diags else filter (\(SrcSpanInfo _ _,_,x) -> not(x =~ pat)) diags
+    if | null warns -> success
+       | otherwise -> do
+             let (SrcSpanInfo (SrcSpan _ l c _ _) _,_,x) = head warns
+             failure $ "Warning found at line " ++ show l ++ ", column " ++ show c
+
 checkRule _ = abort
 
 allDefinitionsOf :: String -> Module SrcSpanInfo -> [Rhs SrcSpanInfo]

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
@@ -209,15 +209,15 @@ checkRule (NotThis rule) = do
         Just _ -> success
         Nothing -> abort
 
-checkRule (LineLength len) = do
+checkRule (MaxLineLength len) = do
     src <- getSourceCode
     if | any (> len) (C.length <$> C.lines src) -> 
             failure $ "One or more lines longer than " ++ show len ++ " characters."
        | otherwise -> success
 
-checkRule (NoWarnings b pat) = do
+checkRule (NoWarningsExcept ex) = do
     diags <- getDiagnostics
-    let warns = if b then diags else filter (\(SrcSpanInfo _ _,_,x) -> not(x =~ pat)) diags
+    let warns = filter (\(SrcSpanInfo _ _,_,x) -> not (any (x =~) ex)) diags
     if | null warns -> success
        | otherwise -> do
              let (SrcSpanInfo (SrcSpan _ l c _ _) _,_,x) = head warns

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
@@ -34,6 +34,7 @@ import Data.Either
 import Data.Generics hiding (empty)
 import Data.Hashable
 import qualified Data.Text as T
+import qualified Data.ByteString.Char8 as C
 import Data.Void
 import Language.Haskell.Exts hiding (Rule, parse)
 import Text.Regex.TDFA hiding (match)
@@ -207,6 +208,12 @@ checkRule (NotThis rule) = do
         Just [] -> failure "A rule matched, but shouldn't have."
         Just _ -> success
         Nothing -> abort
+
+checkRule (LineLength len) = do
+    src <- getSourceCode
+    if | any (> len) (C.length <$> C.lines src) -> 
+            failure $ "One or more lines longer than " ++ show len ++ " characters."
+       | otherwise -> success
 
 checkRule _ = abort
 

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Language.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Language.hs
@@ -55,8 +55,8 @@ instance FromJSON Rule where
             , explicitParseFieldMaybe allOf o "all"
             , explicitParseFieldMaybe anyOf o "any"
             , explicitParseFieldMaybe notThis o "not"
-            , explicitParseFieldMaybe lineLength o "lineLength"
-            , explicitParseFieldMaybe noWarnings o "noWarnings"
+            , explicitParseFieldMaybe maxLineLength o "maxLineLength"
+            , explicitParseFieldMaybe noWarningsExcept o "noWarningsExcept"
             ]
         case catMaybes choices of
             [r] -> decorateWith o r
@@ -121,13 +121,11 @@ anyOf v = AnyOf <$> withArray "any" (mapM parseJSON . toList) v
 notThis :: Aeson.Value -> Aeson.Parser Rule
 notThis v = NotThis <$> parseJSON v
 
-lineLength :: Aeson.Value -> Aeson.Parser Rule
-lineLength v = LineLength <$> parseJSON v
+maxLineLength :: Aeson.Value -> Aeson.Parser Rule
+maxLineLength v = MaxLineLength <$> parseJSON v
 
-noWarnings :: Aeson.Value -> Aeson.Parser Rule
-noWarnings = withObject "noWarnings" $ \o ->
-    NoWarnings <$> o .: "strict"
-               <*> o .:? "exceptions" .!= "$."
+noWarningsExcept :: Aeson.Value -> Aeson.Parser Rule
+noWarningsExcept v = NoWarningsExcept <$> withArray "exceptions" (mapM parseJSON . toList) v
 
 instance FromJSON Cardinality where
     parseJSON val = parseAsNum val <|> parseAsObj val

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Language.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Language.hs
@@ -55,6 +55,7 @@ instance FromJSON Rule where
             , explicitParseFieldMaybe allOf o "all"
             , explicitParseFieldMaybe anyOf o "any"
             , explicitParseFieldMaybe notThis o "not"
+            , explicitParseFieldMaybe lineLength o "lineLength"
             ]
         case catMaybes choices of
             [r] -> decorateWith o r
@@ -118,6 +119,9 @@ anyOf v = AnyOf <$> withArray "any" (mapM parseJSON . toList) v
 
 notThis :: Aeson.Value -> Aeson.Parser Rule
 notThis v = NotThis <$> parseJSON v
+
+lineLength :: Aeson.Value -> Aeson.Parser Rule
+lineLength v = LineLength <$> parseJSON v
 
 instance FromJSON Cardinality where
     parseJSON val = parseAsNum val <|> parseAsObj val

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Language.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Language.hs
@@ -56,6 +56,7 @@ instance FromJSON Rule where
             , explicitParseFieldMaybe anyOf o "any"
             , explicitParseFieldMaybe notThis o "not"
             , explicitParseFieldMaybe lineLength o "lineLength"
+            , explicitParseFieldMaybe noWarnings o "noWarnings"
             ]
         case catMaybes choices of
             [r] -> decorateWith o r
@@ -122,6 +123,11 @@ notThis v = NotThis <$> parseJSON v
 
 lineLength :: Aeson.Value -> Aeson.Parser Rule
 lineLength v = LineLength <$> parseJSON v
+
+noWarnings :: Aeson.Value -> Aeson.Parser Rule
+noWarnings = withObject "noWarnings" $ \o ->
+    NoWarnings <$> o .: "strict"
+               <*> o .:? "exceptions" .!= "$."
 
 instance FromJSON Cardinality where
     parseJSON val = parseAsNum val <|> parseAsObj val

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Types.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Types.hs
@@ -42,11 +42,8 @@ data Rule = DefinedByFunction String String
           | AllOf [Rule]
           | AnyOf [Rule]
           | NotThis Rule
-          | LineLength Int
-          | NoWarnings {
-              strict :: Bool,
-              exceptions :: String
-          }
+          | MaxLineLength Int
+          | NoWarningsExcept [String]
     deriving Show
 
 data Cardinality = Cardinality {

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Types.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Types.hs
@@ -42,6 +42,7 @@ data Rule = DefinedByFunction String String
           | AllOf [Rule]
           | AnyOf [Rule]
           | NotThis Rule
+          | LineLength Int
     deriving Show
 
 data Cardinality = Cardinality {

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Types.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Types.hs
@@ -43,6 +43,10 @@ data Rule = DefinedByFunction String String
           | AnyOf [Rule]
           | NotThis Rule
           | LineLength Int
+          | NoWarnings {
+              strict :: Bool,
+              exceptions :: String
+          }
     deriving Show
 
 data Cardinality = Cardinality {


### PR DESCRIPTION
This adds two new types of requirement rule to the requirements checker.

The first is line length, which simply takes an integer and fails if any of the lines in the source code are above the length given.

The second is checking for warnings. This can either be strict, in which case it will fail if any warnings arise once the code is compiled, or otherwise a regular expression can be given to provide exceptions to the rule, so it will check for any warnings that do not match the regular expression.