### PR TITLE
Revert "install.sh: Install hsc2hs via cabal"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -212,7 +212,7 @@ function fix_libexec_binary {
 }
 
 if [ ! -f $BUILD/progress/ghcjs ]; then
-  run .            cabal v2-install happy-1.19.9 alex hsc2hs --symlink-bindir=$BUILD/bin
+  run .            cabal v2-install happy-1.19.9 alex --symlink-bindir=$BUILD/bin
   run $BUILD       rm -rf ghcjs
   run $BUILD       git clone --branch ghc-8.6 --single-branch https://github.com/ghcjs/ghcjs.git
   run $BUILD/ghcjs git submodule update --init --recursive


### PR DESCRIPTION
ghcup now also exposes hsc2hs. See
https://gitlab.haskell.org/haskell/ghcup/commit/c984cafb1c078d42e196196eb21005fda74784d7

This reverts commit 5d33d9ace627f84d8d8df4f1c00c3f9306ab4ef6.