### PR TITLE
codeworld-api: Remove dependency on random-shuffle

### DIFF
--- a/codeworld-api/codeworld-api.cabal
+++ b/codeworld-api/codeworld-api.cabal
@@ -47,7 +47,6 @@ Library
                        text                 >= 1.2.2 && < 1.3,
                        mtl                  >= 2.2.1 && < 2.3,
                        random               >= 1.1   && < 1.2,
-                       random-shuffle       >= 0.0.4 && < 0.1,
                        cereal               >= 0.5.4 && < 0.6,
                        cereal-text          >= 0.1.0 && < 0.2,
                        ghc-prim             >= 0.3.1 && < 0.6
@@ -94,7 +93,6 @@ Test-suite unit-tests
                        text                 >= 1.2.2 && < 1.3,
                        mtl                  >= 2.2.1 && < 2.3,
                        random               >= 1.1   && < 1.2,
-                       random-shuffle       >= 0.0.4 && < 0.1,
                        cereal               >= 0.5.4 && < 0.6,
                        cereal-text          >= 0.1.0 && < 0.2,
                        ghc-prim             >= 0.3.1 && < 0.6


### PR DESCRIPTION
I forgot to do this in #1027.