### PR TITLE
Renaming/typechecking stage for requirements checker

### DIFF
--- a/codeworld-requirements/codeworld-requirements.cabal
+++ b/codeworld-requirements/codeworld-requirements.cabal
@@ -13,13 +13,13 @@ extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     RequirementsChecker
-  other-modules:       Framework
-                       Requirements
-                       Requirements.Eval
-                       Requirements.Language
-                       Requirements.Matcher
-                       Requirements.Types
+  exposed-modules:     CodeWorld.Requirements.RequirementsChecker
+  other-modules:       CodeWorld.Requirements.Framework
+                       CodeWorld.Requirements.Requirements
+                       CodeWorld.Requirements.Checker.Eval
+                       CodeWorld.Requirements.Checker.Language
+                       CodeWorld.Requirements.Checker.Matcher
+                       CodeWorld.Requirements.Checker.Types
   -- other-extensions:
   build-depends:       base,
                        aeson,

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Eval.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Eval.hs
@@ -20,14 +20,14 @@
   limitations under the License.
 -}
 
-module Requirements.Eval (
+module CodeWorld.Requirements.Checker.Eval (
     Requirement,
     evalRequirement
     ) where
 
-import Framework
-import Requirements.Matcher
-import Requirements.Types
+import CodeWorld.Requirements.Framework
+import CodeWorld.Requirements.Checker.Matcher
+import CodeWorld.Requirements.Checker.Types
 import Control.Monad.IO.Class
 import Data.Array
 import Data.Char

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Eval.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Eval.hs
@@ -54,8 +54,8 @@ import TcRnTypes
 import Var
 
 evalRequirement :: DynFlags -> Messages -> TcGblEnv -> HsModule GhcPs -> C.ByteString -> Requirement -> (Maybe Bool, [String])
-evalRequirement e c f m s Requirement{..} = let
-        results = map (checkRule e c f m s) requiredRules
+evalRequirement f c e m s Requirement{..} = let
+        results = map (checkRule f c e m s) requiredRules
         evals = if any isNothing results then Nothing else Just $ concat (catMaybes results)
     in case evals of
         Nothing -> (Nothing, ["Could not check this requirement."])

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Language.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Language.hs
@@ -17,10 +17,10 @@
   limitations under the License.
 -}
 
-module Requirements.Language (parseRequirement) where
+module CodeWorld.Requirements.Checker.Language (parseRequirement) where
 
-import Framework
-import Requirements.Types
+import CodeWorld.Requirements.Framework
+import CodeWorld.Requirements.Checker.Types
 import Control.Applicative
 import Data.Aeson
 import Data.Aeson.Types (explicitParseFieldMaybe)

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Matcher.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Matcher.hs
@@ -19,7 +19,7 @@
   limitations under the License.
 -}
 
-module Requirements.Matcher where
+module CodeWorld.Requirements.Checker.Matcher where
 
 import Control.Monad
 import Data.Generics

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
@@ -66,11 +66,11 @@ module CodeWorld.Requirements.Checker.Types where
     getStage (NotUsed _) = Parse
     getStage (ContainsMatch{}) = Parse
     getStage (MatchesRegex{}) = Source
-    getStage (OnFailure _ r) = getStage r
+    getStage (OnFailure _ _) = Multiple
     getStage (IfThen _ _) = Multiple
     getStage (AllOf _) = Multiple
     getStage (AnyOf _) = Multiple
-    getStage (NotThis r) = getStage r
+    getStage (NotThis _) = Multiple
     getStage (MaxLineLength _) = Source
     getStage (NoWarningsExcept _) = Typecheck
     getStage (TypeSignatures _) = Parse

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
@@ -74,8 +74,8 @@ module CodeWorld.Requirements.Checker.Types where
     getStage (MaxLineLength _) = Source
     getStage (NoWarningsExcept _) = Typecheck
     getStage (TypeSignatures _) = Parse
-    getStage (Blacklist _) = Parse -- Typecheck
-    getStage (Whitelist _) = Parse -- Typecheck
+    getStage (Blacklist _) = Typecheck
+    getStage (Whitelist _) = Typecheck
     
     anyNumber, exactlyOne, atLeastOne :: Cardinality
     anyNumber = Cardinality Nothing Nothing

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
@@ -14,7 +14,7 @@
   limitations under the License.
 -}
 
-module Requirements.Types where
+module CodeWorld.Requirements.Checker.Types where
 
     data Requirement = Requirement {
         requiredDescription :: String,

--- a/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Checker/Types.hs
@@ -72,7 +72,7 @@ module CodeWorld.Requirements.Checker.Types where
     getStage (AnyOf _) = Multiple
     getStage (NotThis r) = getStage r
     getStage (MaxLineLength _) = Source
-    getStage (NoWarningsExcept _) = Parse -- Typecheck
+    getStage (NoWarningsExcept _) = Typecheck
     getStage (TypeSignatures _) = Parse
     getStage (Blacklist _) = Parse -- Typecheck
     getStage (Whitelist _) = Parse -- Typecheck

--- a/codeworld-requirements/src/CodeWorld/Requirements/Framework.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Framework.hs
@@ -23,7 +23,7 @@
   limitations under the License.
 -}
 
-module Framework where
+module CodeWorld.Requirements.Framework where
 
 import Control.Applicative
 import Control.Concurrent

--- a/codeworld-requirements/src/CodeWorld/Requirements/Requirements.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Requirements.hs
@@ -46,13 +46,14 @@ import Text.Regex.TDFA.Text
 
 import DynFlags
 import HsSyn
+import TcRnTypes
 
-checkRequirements :: DynFlags -> HsModule GhcPs -> ByteString -> Maybe String
-checkRequirements f m s = do
+checkRequirements :: DynFlags -> TcGblEnv -> HsModule GhcPs -> ByteString -> Maybe String
+checkRequirements e f m s = do
     let (sources, sdiags) = extractRequirementsSource s
         (reqs, rdiags) = extractRequirements sources
     if (not (null reqs)) then
-        let results = map (handleRequirement f m s) reqs
+        let results = map (handleRequirement e f m s) reqs
             obfuscated = T.unpack (obfuscate (map snd sources))
         in Just $  "\n                      :: REQUIREMENTS ::\n" ++
                    "Obfuscated:\n\n    XREQUIRES" ++ obfuscated ++ "\n\n" ++
@@ -93,10 +94,10 @@ extractRequirements sources = (reqs, diags)
         reqs =  [ req | Right req <- results ]
         format loc err = ("error: The requirement could not be understood:\n" ++ err ++ "\n")
 
-handleRequirement :: DynFlags -> HsModule GhcPs -> ByteString -> Requirement -> String
-handleRequirement f m s req = let
+handleRequirement :: DynFlags -> TcGblEnv -> HsModule GhcPs -> ByteString -> Requirement -> String
+handleRequirement e f m s req = let
     desc = requiredDescription req
-    (success, msgs) = evalRequirement f m s req
+    (success, msgs) = evalRequirement e f m s req
     label | success == Nothing   = "[?] " ++ desc ++ "\n"
           | success == Just True = "[Y] " ++ desc ++ "\n"
           | otherwise            = "[N] " ++ desc ++ "\n"

--- a/codeworld-requirements/src/CodeWorld/Requirements/Requirements.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/Requirements.hs
@@ -19,12 +19,12 @@
   limitations under the License.
 -}
 
-module Requirements (checkRequirements) where
+module CodeWorld.Requirements.Requirements (checkRequirements) where
 
-import Framework
-import Requirements.Eval
-import Requirements.Language
-import Requirements.Types
+import CodeWorld.Requirements.Framework
+import CodeWorld.Requirements.Checker.Eval
+import CodeWorld.Requirements.Checker.Language
+import CodeWorld.Requirements.Checker.Types
 import Codec.Compression.Zlib
 import Control.Exception
 import Control.Monad

--- a/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
@@ -14,9 +14,9 @@
   limitations under the License.
 -}
 
-module RequirementsChecker (plugin) where
+module CodeWorld.Requirements.RequirementsChecker (plugin) where
 
-    import Requirements
+    import CodeWorld.Requirements.Requirements
     import Control.Monad.IO.Class
     import qualified Data.ByteString as B
 

--- a/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
@@ -34,6 +34,7 @@ module CodeWorld.Requirements.RequirementsChecker (plugin) where
 
     plugin :: Plugin
     plugin = defaultPlugin {
+        renamedResultAction = keepRenamedSource,
         typeCheckResultAction = \_args -> requirementsChecker
     }
 

--- a/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
@@ -28,6 +28,7 @@ module CodeWorld.Requirements.RequirementsChecker (plugin) where
     import Outputable
     import Plugins
     import SrcLoc
+    import TcRnMonad
     import TcRnTypes
 
 
@@ -45,7 +46,9 @@ module CodeWorld.Requirements.RequirementsChecker (plugin) where
         
         case parsed of
             GHCParsed code -> do
-                let req = checkRequirements flags env code src
+                lcl <- getLclEnv
+                errs <- readTcRef $ tcl_errs lcl
+                let req = checkRequirements flags errs env code src
 
                 case req of
                     Nothing -> return ()

--- a/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
+++ b/codeworld-requirements/src/CodeWorld/Requirements/RequirementsChecker.hs
@@ -18,19 +18,14 @@ module CodeWorld.Requirements.RequirementsChecker (plugin) where
 
     import CodeWorld.Requirements.Framework
     import CodeWorld.Requirements.Requirements
-    import Control.Monad.IO.Class
     import qualified Data.ByteString as B
     import Data.Text.Encoding
 
-    import Bag
     import ErrUtils
     import HscTypes
     import Outputable
     import Plugins
-    import SrcLoc
     import TcRnMonad
-    import TcRnTypes
-
 
     plugin :: Plugin
     plugin = defaultPlugin {


### PR DESCRIPTION
This still isn't integrated properly and used by CodeWorld for the requirements checking due to my issues with ghcjs-boot preventing me from building CodeWorld currently, but I thought it was worth making a pull request for the work I've been doing on the requirements checker so I don't get too many commits ahead.

This adds the rules that are checked after renaming or typechecking to the requirements checker, currently including the no warnings rule which is checked after typechecking to ensure that all warnings are counted, and the blacklist/whitelist rules which are now checked after renaming rather than after parsing. (This also means that all the rules which were implemented in CodeWorld are now implemented in the plugin version of the requirements checker.) This pull request also reorganises the structure of modules within the requirements checker, to better match the other CodeWorld projects and in preparation for integration.