### PR TITLE
 Upgrade ghc-lib-parser compatibility to latest version

### DIFF
--- a/codeworld-compiler/codeworld-compiler.cabal
+++ b/codeworld-compiler/codeworld-compiler.cabal
@@ -54,8 +54,7 @@ Library
     directory,
     exceptions,
     filepath,
-    -- Later versions renamed Platform to GHC.Platform
-    ghc-lib-parser <= 0.20190603,
+    ghc-lib-parser,
     hashable,
     haskell-src-exts >= 1.20,
     megaparsec,

--- a/codeworld-compiler/src/CodeWorld/Compile/Framework.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Framework.hs
@@ -62,7 +62,7 @@ import qualified "ghc-lib-parser" HscTypes as GHCParse
 import qualified "ghc-lib-parser" Lexer as GHCParse
 import qualified "ghc-lib-parser" Panic as GHCParse
 import qualified "ghc-lib-parser" Parser as GHCParse
-import qualified "ghc-lib-parser" Platform as GHCParse
+import qualified "ghc-lib-parser" GHC.Platform as GHCParse
 import qualified "ghc-lib-parser" SrcLoc as GHCParse
 import qualified "ghc-lib-parser" StringBuffer as GHCParse
 import qualified "ghc-lib-parser" ToolSettings as GHCParse


### PR DESCRIPTION
Upgrade ghc-lib-parser compatibility to latest version, by updating 'Platform`  reference to 'GHC.Platform'

Fixes https://github.com/google/codeworld/issues/1100

TESTED=Ran `cabal install codeworld-compiler` with this change, and  verified that it fails with  `ghc-lib-parser` unbounded (upgraded) and referring `Platform', and succeeds with `ghc-lib-parser` unbounded and referring `GHC.Platform`.

 