### PR TITLE
Install missing libncurses5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ if [ ! -f $BUILD/progress/system-pkgs ]; then
     run . sudo apt-get install -y psmisc
 
     run . sudo apt-get install -y zlib1g-dev
-    run . sudo apt-get install -y libncurses5-dev
+    run . sudo apt-get install -y libncurses5{,-dev}
 
     # Needed for GHC
     run . sudo apt-get install -y make


### PR DESCRIPTION
Resolves a problem when starting from pristine debian:stable
Installing library in /codeworld/build/.ghcup/ghc/8.6.5/lib/ghc-8.6.5/ghc-8.6.5
"/codeworld/build/.ghcup/ghc/8.6.5/lib/ghc-8.6.5/bin/ghc-pkg" --force --global-package-db "/codeworld/build/.ghcup/ghc/8.6.5/lib/ghc-8.6.5/package.conf.d" update rts/dist/package.conf.install
/codeworld/build/.ghcup/ghc/8.6.5/lib/ghc-8.6.5/bin/ghc-pkg: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
make[1]: *** [ghc.mk:991: install_packages] Error 127
make: *** [Makefile:51: install] Error 2
Failed to install, consider updating this script via: ghcup upgrade
The command '/bin/sh -c ./install.sh' returned a non-zero code: 2