### PR TITLE
exclude ghc-lib-parser-0.20191002

### DIFF
--- a/codeworld-compiler/codeworld-compiler.cabal
+++ b/codeworld-compiler/codeworld-compiler.cabal
@@ -54,7 +54,7 @@ Library
     directory,
     exceptions,
     filepath,
-    ghc-lib-parser < 8.8,
+    ghc-lib-parser < 8.8 && (> 0.20191002 || < 0.20191002),
     hashable,
     haskell-src-exts >= 1.20,
     megaparsec,


### PR DESCRIPTION
This version does not have modules `HsExtension` and `HsSyn`

https://github.com/peterbecich/codeworld/blob/63185c0bd283d86b3b7585c75fd8d662b7df33d6/codeworld-compiler/src/CodeWorld/Compile/Framework.hs#L59-L60

http://hackage.haskell.org/package/ghc-lib-parser-0.20191002