### PR TITLE
Cabal project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-*
 *.swp
 .stack-work
 stack.yaml.lock
+cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,13 @@
+packages:
+  codeworld-account/
+  codeworld-api/
+  codeworld-auth/
+  codeworld-compiler/
+  codeworld-error-sanitizer/
+  codeworld-game-api/
+  codeworld-game-server/
+  codeworld-prediction/
+  codeworld-server/
+  codeworld-base/
+  -- fix compilation without ghcjs
+  -- funblocks-client/

--- a/codeworld-compiler/codeworld-compiler.cabal
+++ b/codeworld-compiler/codeworld-compiler.cabal
@@ -58,7 +58,7 @@ Library
     ghc-boot-th == 8.6.5,
     hashable,
     haskell-src-exts >= 1.20,
-    megaparsec,
+    megaparsec >= 7.0.0 && < 8.0.0,
     memory,
     mtl,
     process,

--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/LegacyLanguage.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/LegacyLanguage.hs
@@ -31,6 +31,7 @@ import qualified Data.Text as T
 import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Char
+import qualified Text.Megaparsec as MP
 import qualified Text.Megaparsec.Char.Lexer as L
 import Text.Regex.TDFA ((=~))
 import Text.Regex.TDFA.Text ()
@@ -145,7 +146,9 @@ parseLegacyRequirement :: Int -> Int -> Text -> Either String Requirement
 parseLegacyRequirement ln col txt =
     either (Left . errorBundlePretty) Right $
         snd $ runParser' legacyRequirementParser initialState
-  where str = T.unpack txt
-        initialState = State str 0 posState
-        posState = PosState str 0 srcPos (mkPos 8) (replicate (col - 1) ' ')
-        srcPos = SourcePos "program.hs" (mkPos ln) (mkPos col)
+  where
+    str = T.unpack txt
+    initialState :: MP.State String
+    initialState = MP.State str 0 posState
+    posState = PosState str 0 srcPos (mkPos 8) (replicate (col - 1) ' ')
+    srcPos = SourcePos "program.hs" (mkPos ln) (mkPos col)


### PR DESCRIPTION
`cabal new-build all` works.  

`cabal new-test all` compiles but the `codeworld-compiler` module tests have other problems, unrelated to the `cabal.project` file as far as I can tell.