### PR TITLE
Stack reinstalls GHC in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,7 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
         - hash -r
+        - travis_retry eval $"stack setup --reinstall ; sleep 10"
         - |
           stack build \
             base-compat \
@@ -221,6 +222,7 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
         - hash -r
+        - travis_retry eval $"stack setup --reinstall ; sleep 10"
         - stack clean --full
         - stack build --dependencies-only
     - stage: build_dependencies
@@ -444,6 +446,7 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
         - hash -r
+        - travis_retry eval $"stack setup --reinstall ; sleep 10"
         - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
         - nvm install 10
         - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
@@ -485,6 +488,7 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
         - hash -r
+        - travis_retry eval $"stack setup --reinstall ; sleep 10"
         - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
         - nvm install 10
         - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
@@ -524,6 +528,7 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
         - hash -r
+        - travis_retry eval $"stack setup --reinstall ; sleep 10"
         - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
         - nvm install 10
         - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH


### PR DESCRIPTION
I believe this particular failure https://travis-ci.org/google/codeworld/jobs/630081765#L372-L408 can be prevented by this PR.  `stack setup --reinstall` was already used elsewhere in the Travis config but not in this failing stage.

I can't explain why some things are cached successfully,
```
10.34s$ travis_retry eval $"stack upgrade --binary-only ; sleep 10"
Current Stack version: 2.1.3, available download version: 2.1.3
Skipping binary upgrade, you are already running the most recent version
```
(presumably not Stack from Ubuntu 18.04 image)
and other things are not:
```
Looked for sandboxed compiler named one of: ["ghc-8.6.5","ghc"]
Could not find it on the paths ["/home/travis/.stack/programs/x86_64-linux/ghc-8.6.5/bin/"]
```