### PR TITLE
fix Stack compilation warning about multiple versions of dependency

### DIFF
--- a/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
+++ b/codeworld-compiler/src/CodeWorld/Compile/Requirements/Eval.hs
@@ -256,8 +256,6 @@ checkRule (Whitelist wl) = withParsedCode $ \m -> do
        | otherwise -> failure $ "The symbol `" ++ head notWhitelisted
            ++ "` is not whitelisted."
 
-checkRule _ = abort
-
 allDefinitionsOf :: String -> HsModule GhcPs -> [GRHSs GhcPs (LHsExpr GhcPs)]
 allDefinitionsOf a m = everything (++) (mkQ [] defs) m
   where defs :: HsBind GhcPs -> [GRHSs GhcPs (LHsExpr GhcPs)]

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,6 @@ extra-deps:
   - blank-canvas-0.6.3
   - colour-2.3.4
   - constraints-extras-0.3.0.2
-  - containers-0.6.2.1
   - dependent-map-0.3
   - dependent-sum-0.6.1
   - ghc-lib-parser-8.8.1


### PR DESCRIPTION
This PR fixes this warning from Stack: https://travis-ci.org/google/codeworld/jobs/631590420#L453-L485

and also fixes an unrelated warning about an unused `checkRule` case.