### PR TITLE
disable Travis CI GHCJS stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,39 +7,40 @@ cache:
   timeout: 2000
   directories:
   - $HOME/.cabal
-  - $HOME/.ghc
-  - $HOME/.ghcjs
+  # - $HOME/.ghc
+  # - $HOME/.ghcjs
   - $HOME/.local/bin
   - $HOME/.stack
   - $TRAVIS_BUILD_DIR/.stack-work
-  - $TRAVIS_BUILD_DIR/ghcjs/.cabal-sandbox
-  - $TRAVIS_BUILD_DIR/ghcjs/data
-  - $TRAVIS_BUILD_DIR/ghcjs/dist
-  - $TRAVIS_BUILD_DIR/ghcjs/dist-newstyle
-  - $TRAVIS_BUILD_DIR/ghcjs/ghcjs-boot
-  - $TRAVIS_BUILD_DIR/ghcjs/lib
-  - $TRAVIS_BUILD_DIR/ghcjs/lib/boot/data
-  - $TRAVIS_BUILD_DIR/ghcjs/lib/boot/pkg
-  - $TRAVIS_BUILD_DIR/ghcjs/utils
-  - $TRAVIS_BUILD_DIR/ghcjs/vendor
+  # - $TRAVIS_BUILD_DIR/ghcjs/.cabal-sandbox
+  # - $TRAVIS_BUILD_DIR/ghcjs/data
+  # - $TRAVIS_BUILD_DIR/ghcjs/dist
+  # - $TRAVIS_BUILD_DIR/ghcjs/dist-newstyle
+  # - $TRAVIS_BUILD_DIR/ghcjs/ghcjs-boot
+  # - $TRAVIS_BUILD_DIR/ghcjs/lib
+  # - $TRAVIS_BUILD_DIR/ghcjs/lib/boot/data
+  # - $TRAVIS_BUILD_DIR/ghcjs/lib/boot/pkg
+  # - $TRAVIS_BUILD_DIR/ghcjs/utils
+  # - $TRAVIS_BUILD_DIR/ghcjs/vendor
 
 addons:
   apt:
     update: false
 
-stages:
-  - upgrade_stack
-  - build_some_dependencies
-  - build_dependencies
-  - build
-  - test
-  # - build_ghcjs_dependencies
-  # - build_ghcjs
-  # - install_ghcjs
-  # - boot_ghcjs
-  # - build_with_ghcjs_dependencies
-  # - build_with_ghcjs
-  # - test_with_ghcjs
+# `stages` apparently has no effect when `jobs` defined
+# stages:
+#   - upgrade_stack
+#   - build_some_dependencies
+#   - build_dependencies
+#   - build
+#   - test
+#   - build_ghcjs_dependencies
+#   - build_ghcjs
+#   - install_ghcjs
+#   - boot_ghcjs
+#   - build_with_ghcjs_dependencies
+#   - build_with_ghcjs
+#   - test_with_ghcjs
 
 jobs:
   include:
@@ -470,324 +471,324 @@ jobs:
     #     - PACKAGE="funblocks-client"
     #     - JOB=12
     #   script: *test
-    - stage: build_ghcjs_dependencies
-      name: "API"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &build_ghcjs_dependencies
-        - sleep $(((JOB - 1) * 10))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 10"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 10"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - travis_retry eval $"cabal new-update ; sleep 10"
-        - cabal new-configure
-        - cabal new-build -j --only-dependencies --disable-optimization
-    - stage: build_ghcjs_dependencies
-      name: "Base"
-      env:
-        - PACKAGE="codeworld-base"
-        - JOB=5
-      script: *build_ghcjs_dependencies
-    - stage: build_ghcjs_dependencies
-      name: "Prediction"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *build_ghcjs_dependencies
-    - stage: build_ghcjs_dependencies
-      name: "Funblocks Client"
-      env:
-        - PACKAGE="funblocks-client"
-        - JOB=12
-      script: *build_ghcjs_dependencies
-    - stage: build_ghcjs
-      name: "API"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &build_ghcjs
-        - sleep $(((JOB - 1) * 10))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 10"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 10"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - cabal new-build -j
-    - stage: build_ghcjs
-      name: "Base"
-      env:
-        - PACKAGE="codeworld-base"
-        - JOB=5
-      script: *build_ghcjs
-    - stage: build_ghcjs
-      name: "Prediction"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *build_ghcjs
-    - stage: build_ghcjs
-      name: "Funblocks Client"
-      env:
-        - PACKAGE="funblocks-client"
-        - JOB=12
-      script: *build_ghcjs
-    - stage: install_ghcjs
-      name: "API"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &install_ghcjs
-        - sleep $(((JOB - 1) * 10))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 10"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 10"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - cabal new-install --only-dependencies --lib
-        - cabal new-install -v --lib
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
-    - stage: install_ghcjs
-      name: "Base"
-      env:
-        - PACKAGE="codeworld-base"
-        - JOB=5
-      script: *install_ghcjs
-    - stage: install_ghcjs
-      name: "Prediction"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *install_ghcjs
-    - stage: install_ghcjs
-      name: "Funblocks Client"
-      env:
-        - PACKAGE="funblocks-client"
-        - JOB=12
-      script: *install_ghcjs
-    - stage: boot_ghcjs
-      name: "API"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &boot_ghcjs
-        - sleep $(((JOB - 1) * 1))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 1"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 1"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 1"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 1"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 1"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - travis_retry git submodule update --init --recursive
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - ghcjs --version
-        - ghcjs-boot --verbosity 0 -j 2 -s $TRAVIS_BUILD_DIR/ghcjs/lib/boot --no-haddock --no-prof
-        - cabal --ghcjs --version
-    - stage: boot_ghcjs
-      name: "Base"
-      env:
-        - PACKAGE="codeworld-base"
-        - JOB=5
-      script: *boot_ghcjs
-    - stage: boot_ghcjs
-      name: "Prediction"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *boot_ghcjs
-    - stage: boot_ghcjs
-      name: "Funblocks Client"
-      env:
-        - PACKAGE="funblocks-client"
-        - JOB=12
-      script: *boot_ghcjs
-    - stage: build_with_ghcjs_dependencies
-      name: "API (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &build_with_ghcjs_dependencies
-        - sleep $(((JOB - 1) * 10))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 10"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 10"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - travis_retry git submodule update --init --recursive
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - cd $TRAVIS_BUILD_DIR
-        - travis_retry eval $"cabal new-update ; sleep 10"
-        - cabal --ghcjs new-configure $PACKAGE
-        - cabal --ghcjs new-build -j --only-dependencies $PACKAGE
-    - stage: build_with_ghcjs_dependencies
-      name: "Base (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-base"
-        - JOB=5
-      script: *build_with_ghcjs_dependencies
-    - stage: build_with_ghcjs_dependencies
-      name: "Prediction (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *build_with_ghcjs_dependencies
-    - stage: build_with_ghcjs_dependencies
-      name: "Funblocks Client (with ghcjs)"
-      env:
-        - PACKAGE="funblocks-client"
-        - JOB=12
-      script: *build_with_ghcjs_dependencies
-    - stage: build_with_ghcjs
-      name: "API (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &build_with_ghcjs
-        - sleep $(((JOB - 1) * 10))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 10"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 10"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - travis_retry git submodule update --init --recursive
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - cd $TRAVIS_BUILD_DIR
-        - travis_retry eval $"cabal new-update ; sleep 10"
-        - cabal --ghcjs new-configure $PACKAGE
-        - cabal --ghcjs new-build -j $PACKAGE
-    - stage: build_with_ghcjs
-      name: "Base (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-base"
-        - JOB=5
-      script: *build_with_ghcjs
-    - stage: build_with_ghcjs
-      name: "Prediction (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *build_with_ghcjs
-    - stage: build_with_ghcjs
-      name: "Funblocks Client (with ghcjs)"
-      env:
-        - PACKAGE="funblocks-client"
-        - JOB=12
-      script: *build_with_ghcjs
-    - stage: test_with_ghcjs
-      name: "API (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-api"
-        - JOB=3
-      script: &test_with_ghcjs
-        - sleep $(((JOB - 1) * 10))
-        - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
-        - travis_retry eval $"sudo apt-get update ; sleep 10"
-        - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
-        - hash -r
-        - travis_retry eval $"stack setup --reinstall ; sleep 10"
-        - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
-        - nvm install 10
-        - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
-        - export
-        - travis_retry git submodule update --init --recursive
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
-        - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
-        - cd ghcjs
-        - travis_retry git submodule update --init --recursive
-        - ./utils/makePackages.sh
-        - cd $TRAVIS_BUILD_DIR
-        - travis_retry eval $"cabal new-update ; sleep 10"
-        - cabal --ghcjs new-configure $PACKAGE
-        - cabal --ghcjs new-test $PACKAGE
-    - stage: test_with_ghcjs
-      name: "Prediction (with ghcjs)"
-      env:
-        - PACKAGE="codeworld-prediction"
-        - JOB=10
-      script: *test_with_ghcjs
-    # - stage: test_with_ghcjs
+    # - stage: build_ghcjs_dependencies
+    #   name: "API"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &build_ghcjs_dependencies
+    #     - sleep $(((JOB - 1) * 10))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 10"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 10"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - travis_retry eval $"cabal new-update ; sleep 10"
+    #     - cabal new-configure
+    #     - cabal new-build -j --only-dependencies --disable-optimization
+    # - stage: build_ghcjs_dependencies
+    #   name: "Base"
+    #   env:
+    #     - PACKAGE="codeworld-base"
+    #     - JOB=5
+    #   script: *build_ghcjs_dependencies
+    # - stage: build_ghcjs_dependencies
+    #   name: "Prediction"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
+    #   script: *build_ghcjs_dependencies
+    # - stage: build_ghcjs_dependencies
+    #   name: "Funblocks Client"
+    #   env:
+    #     - PACKAGE="funblocks-client"
+    #     - JOB=12
+    #   script: *build_ghcjs_dependencies
+    # - stage: build_ghcjs
+    #   name: "API"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &build_ghcjs
+    #     - sleep $(((JOB - 1) * 10))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 10"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 10"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - cabal new-build -j
+    # - stage: build_ghcjs
+    #   name: "Base"
+    #   env:
+    #     - PACKAGE="codeworld-base"
+    #     - JOB=5
+    #   script: *build_ghcjs
+    # - stage: build_ghcjs
+    #   name: "Prediction"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
+    #   script: *build_ghcjs
+    # - stage: build_ghcjs
+    #   name: "Funblocks Client"
+    #   env:
+    #     - PACKAGE="funblocks-client"
+    #     - JOB=12
+    #   script: *build_ghcjs
+    # - stage: install_ghcjs
+    #   name: "API"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &install_ghcjs
+    #     - sleep $(((JOB - 1) * 10))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 10"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 10"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - cabal new-install --only-dependencies --lib
+    #     - cabal new-install -v --lib
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
+    # - stage: install_ghcjs
+    #   name: "Base"
+    #   env:
+    #     - PACKAGE="codeworld-base"
+    #     - JOB=5
+    #   script: *install_ghcjs
+    # - stage: install_ghcjs
+    #   name: "Prediction"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
+    #   script: *install_ghcjs
+    # - stage: install_ghcjs
+    #   name: "Funblocks Client"
+    #   env:
+    #     - PACKAGE="funblocks-client"
+    #     - JOB=12
+    #   script: *install_ghcjs
+    # - stage: boot_ghcjs
+    #   name: "API"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &boot_ghcjs
+    #     - sleep $(((JOB - 1) * 1))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 1"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 1"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 1"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 1"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 1"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - travis_retry git submodule update --init --recursive
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - ghcjs --version
+    #     - ghcjs-boot --verbosity 0 -j 2 -s $TRAVIS_BUILD_DIR/ghcjs/lib/boot --no-haddock --no-prof
+    #     - cabal --ghcjs --version
+    # - stage: boot_ghcjs
+    #   name: "Base"
+    #   env:
+    #     - PACKAGE="codeworld-base"
+    #     - JOB=5
+    #   script: *boot_ghcjs
+    # - stage: boot_ghcjs
+    #   name: "Prediction"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
+    #   script: *boot_ghcjs
+    # - stage: boot_ghcjs
+    #   name: "Funblocks Client"
+    #   env:
+    #     - PACKAGE="funblocks-client"
+    #     - JOB=12
+    #   script: *boot_ghcjs
+    # - stage: build_with_ghcjs_dependencies
+    #   name: "API (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &build_with_ghcjs_dependencies
+    #     - sleep $(((JOB - 1) * 10))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 10"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 10"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - travis_retry git submodule update --init --recursive
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - cd $TRAVIS_BUILD_DIR
+    #     - travis_retry eval $"cabal new-update ; sleep 10"
+    #     - cabal --ghcjs new-configure $PACKAGE
+    #     - cabal --ghcjs new-build -j --only-dependencies $PACKAGE
+    # - stage: build_with_ghcjs_dependencies
+    #   name: "Base (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-base"
+    #     - JOB=5
+    #   script: *build_with_ghcjs_dependencies
+    # - stage: build_with_ghcjs_dependencies
+    #   name: "Prediction (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
+    #   script: *build_with_ghcjs_dependencies
+    # - stage: build_with_ghcjs_dependencies
     #   name: "Funblocks Client (with ghcjs)"
     #   env:
     #     - PACKAGE="funblocks-client"
     #     - JOB=12
+    #   script: *build_with_ghcjs_dependencies
+    # - stage: build_with_ghcjs
+    #   name: "API (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &build_with_ghcjs
+    #     - sleep $(((JOB - 1) * 10))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 10"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 10"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - travis_retry git submodule update --init --recursive
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - cd $TRAVIS_BUILD_DIR
+    #     - travis_retry eval $"cabal new-update ; sleep 10"
+    #     - cabal --ghcjs new-configure $PACKAGE
+    #     - cabal --ghcjs new-build -j $PACKAGE
+    # - stage: build_with_ghcjs
+    #   name: "Base (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-base"
+    #     - JOB=5
+    #   script: *build_with_ghcjs
+    # - stage: build_with_ghcjs
+    #   name: "Prediction (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
+    #   script: *build_with_ghcjs
+    # - stage: build_with_ghcjs
+    #   name: "Funblocks Client (with ghcjs)"
+    #   env:
+    #     - PACKAGE="funblocks-client"
+    #     - JOB=12
+    #   script: *build_with_ghcjs
+    # - stage: test_with_ghcjs
+    #   name: "API (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-api"
+    #     - JOB=3
+    #   script: &test_with_ghcjs
+    #     - sleep $(((JOB - 1) * 10))
+    #     - travis_retry sudo add-apt-repository --yes ppa:hvr/ghc
+    #     - travis_retry eval $"sudo apt-get update ; sleep 10"
+    #     - travis_retry eval $"sudo apt-get install --yes build-essential cabal-install-2.4 ghc-8.6.5 libgmp-dev haskell-stack ; sleep 10"
+    #     - export PATH=$HOME/.local/bin:$PATH
+    #     - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
+    #     - hash -r
+    #     - travis_retry eval $"stack setup --reinstall ; sleep 10"
+    #     - travis_retry eval $"stack install --resolver lts-14.11 happy-1.19.9 alex-3.2.4 ; sleep 10"
+    #     - nvm install 10
+    #     - export PATH=$PWD/.cabal-sandbox/bin:$HOME/.cabal/bin:/opt/ghc/8.6.5/bin:/opt/cabal/2.4/bin:$PATH
+    #     - export
+    #     - travis_retry git submodule update --init --recursive
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-pkg
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/haddock-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/hsc2hs-ghcjs
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-boot
+    #     - sudo ln -fs $TRAVIS_BUILD_DIR/ghcjs/utils/dist-newstyle-wrapper.sh /usr/bin/ghcjs-run
+    #     - cd ghcjs
+    #     - travis_retry git submodule update --init --recursive
+    #     - ./utils/makePackages.sh
+    #     - cd $TRAVIS_BUILD_DIR
+    #     - travis_retry eval $"cabal new-update ; sleep 10"
+    #     - cabal --ghcjs new-configure $PACKAGE
+    #     - cabal --ghcjs new-test $PACKAGE
+    # - stage: test_with_ghcjs
+    #   name: "Prediction (with ghcjs)"
+    #   env:
+    #     - PACKAGE="codeworld-prediction"
+    #     - JOB=10
     #   script: *test_with_ghcjs
+    # # - stage: test_with_ghcjs
+    # #   name: "Funblocks Client (with ghcjs)"
+    # #   env:
+    # #     - PACKAGE="funblocks-client"
+    # #     - JOB=12
+    # #   script: *test_with_ghcjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ stages:
   - build_dependencies
   - build
   - test
-  - build_ghcjs_dependencies
-  - build_ghcjs
-  - install_ghcjs
-  - boot_ghcjs
-  - build_with_ghcjs_dependencies
-  - build_with_ghcjs
-  - test_with_ghcjs
+  # - build_ghcjs_dependencies
+  # - build_ghcjs
+  # - install_ghcjs
+  # - boot_ghcjs
+  # - build_with_ghcjs_dependencies
+  # - build_with_ghcjs
+  # - test_with_ghcjs
 
 jobs:
   include:


### PR DESCRIPTION
I probably ought to stop trying to fix these brittle Travis stages to set up GHCJS, and instead think about something like Miso's config: https://github.com/dmjio/miso/blob/master/.travis.yml

I'm aware of issues such as https://github.com/google/codeworld/issues/1182 which discuss Nix, and also of the patch required https://github.com/google/codeworld/blob/43d26a64a8c6b6279a314741a51cb04a1935e465/install.sh#L221 which might complicate copying Miso's config.