### PR TITLE
Use directory tree state as a single source of truth.

### DIFF
--- a/web/blocks.html
+++ b/web/blocks.html
@@ -114,6 +114,8 @@
     <script type="text/javascript" src="js/details-element-polyfill.js"></script>
 
     <!-- Initialization in JS -->
+    <script src="js/utils/index.js"></script>
+    <script src="js/utils/directoryTree.js"></script>
     <script src="js/codeworld_shared.js"></script>
     <script src="js/funblocks.js"></script>
 

--- a/web/env.html
+++ b/web/env.html
@@ -166,6 +166,8 @@
     <script type="text/javascript" src="js/codemirror-compressed.js" charset="UTF-8"></script>
     <script type="text/javascript" src="js/codemirror-buttons/buttons.js"></script>
     <script type="text/javascript" src="js/details-element-polyfill.js"></script>
+    <script type="text/javascript" src="js/utils/index.js"></script>
+    <script type="text/javascript" src="js/utils/directoryTree.js"></script>
     <script type="text/javascript" src="js/codeworld-mode.js"></script>
     <script type="text/javascript" src="js/codeworld_shared.js"></script>
     <script type="text/javascript" src="js/codeworld.js"></script>

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -782,9 +782,9 @@ function loadSample(code) {
 }
 
 function newProject() {
-    utils.directoryTree.clearSelectedNode();
-
     warnIfUnsaved(() => {
+        utils.directoryTree.clearSelectedNode();
+
         setCode('');
     });
 }

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -589,13 +589,13 @@ function setMode(force) {
 }
 
 function getCurrentProject() {
-  const doc = window.codeworldEditor.getDoc()
+    const doc = window.codeworldEditor.getDoc();
 
-  return {
-    name: utils.directoryTree.getCurrentProjectName() || 'Untitled',
-    source: doc.getValue(),
-    history: doc.getHistory()
-  }
+    return {
+        name: utils.directoryTree.getCurrentProjectName() || 'Untitled',
+        source: doc.getValue(),
+        history: doc.getHistory()
+    };
 }
 
 /*
@@ -662,7 +662,7 @@ function updateUI() {
     document.getElementById('saveAsButton').style.display = '';
     document.getElementById('runButtons').style.display = '';
 
-    let title = utils.directoryTree.getCurrentProjectName() || '(new)'
+    let title = utils.directoryTree.getCurrentProjectName() || '(new)';
 
     if (!isEditorClean()) {
         title = `* ${title}`;
@@ -782,11 +782,11 @@ function loadSample(code) {
 }
 
 function newProject() {
-  utils.directoryTree.clearSelectedNode()
+    utils.directoryTree.clearSelectedNode();
 
-  warnIfUnsaved(() => {
-    setCode('')
-  })
+    warnIfUnsaved(() => {
+        setCode('');
+    });
 }
 
 function newFolder() {
@@ -1168,49 +1168,49 @@ function signinCallback(result) {
 
 function saveProject() {
     function successFunc() {
-      const doc = window.codeworldEditor.getDoc()
+        const doc = window.codeworldEditor.getDoc();
 
-      window.savedGeneration = doc.changeGeneration(true)
-      window.codeworldEditor.focus()
+        window.savedGeneration = doc.changeGeneration(true);
+        window.codeworldEditor.focus();
     }
 
-    const currentProjectName = utils.directoryTree.getCurrentProjectName()
+    const currentProjectName = utils.directoryTree.getCurrentProjectName();
 
     if (currentProjectName) {
-      saveProjectBase(
-        getNearestDirectory(),
-        currentProjectName,
-        window.projectEnv,
-        successFunc,
-      )
+        saveProjectBase(
+            getNearestDirectory(),
+            currentProjectName,
+            window.projectEnv,
+            successFunc,
+        );
     } else {
-      saveProjectAs();
+        saveProjectAs();
     }
 }
 
 function saveProjectAs() {
-  function successFunc(name) {
-    const doc = window.codeworldEditor.getDoc()
+    function successFunc(name) {
+        const doc = window.codeworldEditor.getDoc();
 
-    window.savedGeneration = doc.changeGeneration(true)
-    window.codeworldEditor.focus()
-  }
+        window.savedGeneration = doc.changeGeneration(true);
+        window.codeworldEditor.focus();
+    }
 
-  saveProjectAsBase(successFunc)
+    saveProjectAsBase(successFunc);
 }
 
 function deleteFolder() {
-    const path = getNearestDirectory()
+    const path = getNearestDirectory();
 
     if (path === '' || utils.directoryTree.getCurrentProjectName()) {
-      return
+        return;
     }
 
     deleteFolder_(path, window.projectEnv, () => {
-      window.savedGeneration = codeworldEditor.getDoc().changeGeneration(true)
+        window.savedGeneration = codeworldEditor.getDoc().changeGeneration(true);
 
-      clearWorkspace()
-    })
+        clearWorkspace();
+    });
 }
 
 function deleteProject() {
@@ -1236,9 +1236,9 @@ function downloadProject() {
             type: 'text/plain',
             endings: 'native'
         });
-    let filename = `
+    const filename = `
       ${utils.directoryTree.getCurrentProjectName() || 'untitled'}.hs
-    `
+    `;
 
     if (window.navigator.msSaveBlob) {
         window.navigator.msSaveBlob(blob, filename);
@@ -1325,11 +1325,11 @@ function parseCompileErrors(rawErrors) {
 }
 
 function clearWorkspace() {
-  utils.directoryTree.clearSelectedNode()
+    utils.directoryTree.clearSelectedNode();
 
-  setCode('')
+    setCode('');
 }
 
 function clearCode() {
-  setCode('');
+    setCode('');
 }

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -762,26 +762,6 @@ function isEditorClean() {
     else return doc.isClean(window.savedGeneration);
 }
 
-function setCode(code, history, name, autostart) {
-    const doc = codeworldEditor.getDoc();
-    doc.setValue(code);
-    window.savedGeneration = doc.changeGeneration(true);
-
-    if (history) {
-        doc.setHistory(history);
-    } else {
-        doc.clearHistory();
-    }
-
-    codeworldEditor.focus();
-    parseSymbolsFromCurrentCode();
-    if (autostart) {
-        compile();
-    } else {
-        stopRun();
-    }
-}
-
 function loadSample(code) {
     if (isEditorClean()) sweetAlert.close();
     warnIfUnsaved(() => {
@@ -791,17 +771,7 @@ function loadSample(code) {
 
 function newProject() {
     warnIfUnsaved(() => {
-        const selectedNode = utils.directoryTree.getSelectedNode();
-
-        if (selectedNode && utils.directoryTree.isProject(selectedNode)) {
-            utils.directoryTree.clearSelectedNode();
-
-            // Select parent folder (if any) as new project's location is
-            // determined by the selection in the directory tree.
-            if (pathToRootDir(selectedNode)) {
-                utils.directoryTree.selectNode(selectedNode.parent);
-            }
-        }
+        updateTreeOnNewProjectCreation();
 
         setCode('');
     });

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -1168,7 +1168,6 @@ function signinCallback(result) {
 
 function saveProject() {
     function successFunc() {
-      const selected = $('#directoryTree').tree('getSelectedNode');
       const doc = window.codeworldEditor.getDoc()
 
       window.savedGeneration = doc.changeGeneration(true)

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -1070,8 +1070,8 @@ function saveProjectAsBase(successFunc) {
 function saveProjectBase(path, projectName, mode, successFunc) {
     if (!signedIn()) {
         sweetAlert('Oops!', 'You must sign in to save files.', 'error');
-
-        return updateUI();
+        updateUI();
+        return;
     }
 
     if (!projectName) return;
@@ -1100,11 +1100,12 @@ function saveProjectBase(path, projectName, mode, successFunc) {
             sweetAlert.close();
 
             if (request.status !== 200) {
-                return sweetAlert(
+                sweetAlert(
                     'Oops!',
                     'Could not save your project!!!  Please try again.',
                     'error'
                 );
+                return;
             }
 
             successFunc();
@@ -1148,7 +1149,8 @@ function deleteProject_(path, buildMode, successFunc) {
 
     if (!signedIn()) {
         sweetAlert('Oops', 'You must sign in to delete a project.', 'error');
-        return updateUI();
+        updateUI();
+        return;
     }
 
     const currentProjectName = selectedNode.name;
@@ -1234,7 +1236,8 @@ function createFolder(path, buildMode, successFunc) {
                 'You must sign in to create a folder.',
                 'error'
             );
-            return updateUI();
+            updateUI();
+            return;
         }
 
         sweetAlert({
@@ -1264,11 +1267,12 @@ function createFolder(path, buildMode, successFunc) {
 
             sendHttp('POST', 'createFolder', data, request => {
                 if (request.status !== 200) {
-                    return sweetAlert(
+                    sweetAlert(
                         'Oops',
                         'Could not create your directory! Please try again.',
                         'error',
                     );
+                    return;
                 }
 
                 successFunc();
@@ -1427,7 +1431,8 @@ function shareFolder_(mode) {
 
     if (!getNearestDirectory() || (selectedNode && selectedNode.name)) {
         sweetAlert('Oops!', 'You must select a folder to share!', 'error');
-        return updateUI();
+        updateUI();
+        return;
     }
 
     const folderName = Html.encode(getNearestDirectory_().name);

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -872,79 +872,78 @@ function withClientId(f) {
 }
 
 function loadSubTree(node, callback) {
-  if (signedIn() && node === $('#directoryTree').tree('getTree')) {
-    // Root node already loaded
-    if (callback) callback()
-  } else if (signedIn() && node.type === 'directory') {
-    const data = new FormData()
-    data.append('mode', window.projectEnv)
-    data.append('path', getNearestDirectory(node))
+    if (signedIn() && node === $('#directoryTree').tree('getTree')) {
+        // Root node already loaded
+        if (callback) callback();
+    } else if (signedIn() && node.type === 'directory') {
+        const data = new FormData();
+        data.append('mode', window.projectEnv);
+        data.append('path', getNearestDirectory(node));
 
-    showLoadingAnimation(node)
+        showLoadingAnimation(node);
 
-    sendHttp('POST', 'listFolder', data, request => {
-      if (request.status === 200) {
-        const treeNodes = JSON.parse(request.responseText)
+        sendHttp('POST', 'listFolder', data, request => {
+            if (request.status === 200) {
+                const treeNodes = JSON.parse(request.responseText);
 
-        treeNodes.forEach(function assignIdToNode(node) {
-          if (!node.id) {
-            node.id = utils.directoryTree.createNodeId(node.type, node.name)
-          }
-        })
+                treeNodes.forEach((node) => {
+                    if (!node.id) {
+                        node.id = utils.directoryTree.createNodeId(node.type, node.name);
+                    }
+                });
 
-        $('#directoryTree').tree(
-          'loadData',
-          treeNodes.sort((a, b) => a.index > b.index),
-          node,
-        );
-        $('#directoryTree').tree('openNode', node)
+                $('#directoryTree').tree(
+                    'loadData',
+                    treeNodes.sort((a, b) => a.index > b.index),
+                    node,
+                );
+                $('#directoryTree').tree('openNode', node);
 
-        if (callback) {
-          callback()
-        }
-      }
+                if (callback) {
+                    callback();
+                }
+            }
 
-      updateUI()
-      hideLoadingAnimation()
-    })
-  } else {
-    updateUI()
-  }
+            updateUI();
+            hideLoadingAnimation();
+        });
+    } else {
+        updateUI();
+    }
 }
 
 function discoverProjects(path) {
-  if (signedIn()) {
-    const data = new FormData();
+    if (signedIn()) {
+        const data = new FormData();
 
-    data.append('mode', window.projectEnv);
-    data.append('path', path);
+        data.append('mode', window.projectEnv);
+        data.append('path', path);
 
-    showLoadingAnimation();
+        showLoadingAnimation();
 
-    sendHttp('POST', 'listFolder', data, (request) => {
-      if (request.status === 200) {
-        const treeNodes = JSON.parse(request.responseText)
+        sendHttp('POST', 'listFolder', data, (request) => {
+            if (request.status === 200) {
+                const treeNodes = JSON.parse(request.responseText);
 
-        treeNodes.forEach(function assignIdToNode(node) {
-          if (!node.id) {
-            node.id = utils.directoryTree.createNodeId(node.type, node.name)
-          }
-        })
+                treeNodes.forEach((node) => {
+                    if (!node.id) {
+                        node.id = utils.directoryTree.createNodeId(node.type, node.name);
+                    }
+                });
 
-        hideLoadingAnimation();
+                hideLoadingAnimation();
 
-        $('#directoryTree').tree(
-          'loadData',
-          treeNodes.sort((a, b) => a.index > b.index)
-        )
-      }
+                $('#directoryTree').tree(
+                    'loadData',
+                    treeNodes.sort((a, b) => a.index > b.index)
+                );
+            }
 
-      updateUI()
-    })
-  }
-  else {
-    updateUI()
-  }
+            updateUI();
+        });
+    } else {
+        updateUI();
+    }
 }
 
 function moveDirTreeNode(moveFrom, moveTo, isFile, name, buildMode, successFunc) {
@@ -1014,173 +1013,173 @@ function saveProjectAsBase(successFunc) {
     }
 
     sweetAlert({
-      title: Alert.title('Save As', 'mdi-cloud-upload'),
-      html: text,
-      input: 'text',
-      inputValue: utils.directoryTree.getCurrentProjectName() || '',
-      confirmButtonText: 'Save',
-      showCancelButton: true,
-      closeOnConfirm: false,
+        title: Alert.title('Save As', 'mdi-cloud-upload'),
+        html: text,
+        input: 'text',
+        inputValue: utils.directoryTree.getCurrentProjectName() || '',
+        confirmButtonText: 'Save',
+        showCancelButton: true,
+        closeOnConfirm: false,
     }).then(result => {
-      const parent = getNearestDirectory_()
+        const parent = getNearestDirectory_();
 
-      function localSuccessFunc() {
-        const matches = parent.children
-          .filter(n => n.name === result.value && n.type === 'project')
-        let node
-        const type = 'project'
-        const name = result.value
+        function localSuccessFunc() {
+            const matches = parent.children
+                .filter(n => n.name === result.value && n.type === 'project');
+            let node;
+            const type = 'project';
+            const name = result.value;
 
-        if (matches.length === 0) {
-          node = $('#directoryTree').tree(
-            'appendNode', {
-              id: utils.directoryTree.createNodeId(type, name),
-              name,
-              type,
-              data: JSON.stringify(getCurrentProject()),
-            },
-            parent
-          )
-        } else {
-          node = matches[0];
+            if (matches.length === 0) {
+                node = $('#directoryTree').tree(
+                    'appendNode', {
+                        id: utils.directoryTree.createNodeId(type, name),
+                        name,
+                        type,
+                        data: JSON.stringify(getCurrentProject()),
+                    },
+                    parent
+                );
+            } else {
+                node = matches[0];
+            }
+
+            $('#directoryTree').tree('selectNode', node);
+
+            updateChildrenIndexes(parent);
+
+            successFunc(result.value);
         }
-
-        $('#directoryTree').tree('selectNode', node);
-
-        updateChildrenIndexes(parent)
-
-        successFunc(result.value)
-      }
-      if (result && result.value) {
-        saveProjectBase(
-          getNearestDirectory(),
-          result.value,
-          window.projectEnv,
-          localSuccessFunc,
-        )
-      }
-    })
+        if (result && result.value) {
+            saveProjectBase(
+                getNearestDirectory(),
+                result.value,
+                window.projectEnv,
+                localSuccessFunc,
+            );
+        }
+    });
 }
 
 function saveProjectBase(path, projectName, mode, successFunc) {
-  if (!signedIn()) {
-    sweetAlert('Oops!', 'You must sign in to save files.', 'error')
+    if (!signedIn()) {
+        sweetAlert('Oops!', 'You must sign in to save files.', 'error');
 
-    return updateUI()
-  }
+        return updateUI();
+    }
 
-  if (!projectName) return
+    if (!projectName) return;
 
-  function go() {
-    sweetAlert({
-      title: Alert.title(`Saving ${projectName} ...`),
-      text: 'Saving your project.  Please wait.',
-      showConfirmButton: false,
-      showCancelButton: false,
-      showCloseButton: false,
-      allowOutsideClick: false,
-      allowEscapeKey: false,
-      allowEnterKey: false,
-    })
+    function go() {
+        sweetAlert({
+            title: Alert.title(`Saving ${projectName} ...`),
+            text: 'Saving your project.  Please wait.',
+            showConfirmButton: false,
+            showCancelButton: false,
+            showCloseButton: false,
+            allowOutsideClick: false,
+            allowEscapeKey: false,
+            allowEnterKey: false,
+        });
 
-    const project = getCurrentProject()
-    project['name'] = projectName
+        const project = getCurrentProject();
+        project['name'] = projectName;
 
-    const data = new FormData()
-    data.append('project', JSON.stringify(project))
-    data.append('mode', mode)
-    data.append('path', path)
+        const data = new FormData();
+        data.append('project', JSON.stringify(project));
+        data.append('mode', mode);
+        data.append('path', path);
 
-    sendHttp('POST', 'saveProject', data, request => {
-        sweetAlert.close()
+        sendHttp('POST', 'saveProject', data, request => {
+            sweetAlert.close();
 
-        if (request.status !== 200) {
-          return sweetAlert(
-            'Oops!',
-            'Could not save your project!!!  Please try again.',
-            'error'
-          )
-        }
+            if (request.status !== 200) {
+                return sweetAlert(
+                    'Oops!',
+                    'Could not save your project!!!  Please try again.',
+                    'error'
+                );
+            }
 
-        successFunc()
-        updateUI()
-    });
-  }
+            successFunc();
+            updateUI();
+        });
+    }
 
-  if (
-    projectName === utils.directoryTree.getCurrentProjectName() ||
-    getNearestDirectory_().children
-      .filter((n) => n.name === projectName && n.type === 'project')
-      .length === 0
+    if (
+        projectName === utils.directoryTree.getCurrentProjectName() ||
+        getNearestDirectory_().children
+            .filter((n) => n.name === projectName && n.type === 'project')
+            .length === 0
     ) {
-      go()
+        go();
     } else {
-      const msg = `${'Are you sure you want to save over another project?\n\n' +
+        const msg = `${'Are you sure you want to save over another project?\n\n' +
           'The previous contents of '}${projectName
-      } will be permanently destroyed!`
-      sweetAlert({
+        } will be permanently destroyed!`;
+        sweetAlert({
+            title: Alert.title('Warning'),
+            text: msg,
+            type: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#DD6B55',
+            confirmButtonText: 'Yes, overwrite it!'
+        }).then((result) => {
+            if (result && result.value) {
+                go();
+            }
+        });
+    }
+}
+
+function deleteProject_(path, buildMode, successFunc) {
+    if (!utils.directoryTree.getCurrentProjectName()) return;
+
+    if (!signedIn()) {
+        sweetAlert('Oops', 'You must sign in to delete a project.', 'error');
+        return updateUI();
+    }
+
+    const msg =
+        'Deleting a project will throw away all work, and cannot be undone. ' +
+        `Are you sure you want to delete ${utils.directoryTree.getCurrentProjectName()}?`;
+
+    sweetAlert({
         title: Alert.title('Warning'),
         text: msg,
         type: 'warning',
         showCancelButton: true,
         confirmButtonColor: '#DD6B55',
-        confirmButtonText: 'Yes, overwrite it!'
-      }).then((result) => {
-        if (result && result.value) {
-          go()
+        confirmButtonText: 'Yes, delete it!',
+    }).then((result) => {
+        if (
+            result.dismiss === sweetAlert.DismissReason.cancel ||
+            result.dismiss === sweetAlert.DismissReason.backdrop
+        ) {
+            return;
         }
-      })
-    }
-}
 
-function deleteProject_(path, buildMode, successFunc) {
-  if (!utils.directoryTree.getCurrentProjectName()) return
+        const data = new FormData();
+        data.append('name', utils.directoryTree.getCurrentProjectName());
+        data.append('mode', buildMode);
+        data.append('path', path);
 
-  if (!signedIn()) {
-    sweetAlert('Oops', 'You must sign in to delete a project.', 'error')
-    return updateUI()
-  }
+        sendHttp('POST', 'deleteProject', data, request => {
+            if (request.status === 200) {
+                successFunc();
 
-  const msg =
-    'Deleting a project will throw away all work, and cannot be undone. ' +
-    `Are you sure you want to delete ${utils.directoryTree.getCurrentProjectName()}?`
+                const node = $('#directoryTree').tree('getSelectedNode');
+                $('#directoryTree').tree('removeNode', node);
 
-  sweetAlert({
-    title: Alert.title('Warning'),
-    text: msg,
-    type: 'warning',
-    showCancelButton: true,
-    confirmButtonColor: '#DD6B55',
-    confirmButtonText: 'Yes, delete it!',
-  }).then((result) => {
-      if (
-        result.dismiss === sweetAlert.DismissReason.cancel ||
-        result.dismiss === sweetAlert.DismissReason.backdrop
-      ) {
-        return
-      }
-
-      const data = new FormData()
-      data.append('name', utils.directoryTree.getCurrentProjectName())
-      data.append('mode', buildMode)
-      data.append('path', path)
-
-      sendHttp('POST', 'deleteProject', data, request => {
-        if (request.status === 200) {
-          successFunc()
-
-          const node = $('#directoryTree').tree('getSelectedNode')
-          $('#directoryTree').tree('removeNode', node)
-
-          updateUI()
-        }
-      })
-  })
+                updateUI();
+            }
+        });
+    });
 }
 
 function deleteFolder_(path, buildMode, successFunc) {
     if (path === '' || utils.directoryTree.getCurrentProjectName()) {
-      return
+        return;
     }
     if (!signedIn()) {
         sweetAlert('Oops', 'You must sign in to delete a folder.', 'error');
@@ -1220,75 +1219,75 @@ function deleteFolder_(path, buildMode, successFunc) {
 }
 
 function createFolder(path, buildMode, successFunc) {
-  warnIfUnsaved(() => {
-    if (!signedIn()) {
-      sweetAlert(
-        'Oops!',
-        'You must sign in to create a folder.',
-        'error'
-      )
-      return updateUI()
-    }
-
-    sweetAlert({
-      title: Alert.title(
-        'Create Folder',
-        'mdi-folder-plus'
-      ),
-      text: 'Enter a name for your folder:',
-      input: 'text',
-      inputValue: '',
-      confirmButtonText: 'Create',
-      showCancelButton: true,
-    }).then(result => {
-      if (!result.value) {
-        return
-      }
-
-      sweetAlert.close()
-      const data = new FormData()
-      data.append('mode', buildMode)
-
-      path === ''
-        ? data.append('path', result.value)
-        : data.append('path', `${path}/${result.value}`)
-
-      sendHttp('POST', 'createFolder', data, request => {
-        if (request.status !== 200) {
-          return sweetAlert(
-            'Oops',
-            'Could not create your directory! Please try again.',
-            'error',
-          )
+    warnIfUnsaved(() => {
+        if (!signedIn()) {
+            sweetAlert(
+                'Oops!',
+                'You must sign in to create a folder.',
+                'error'
+            );
+            return updateUI();
         }
 
-        successFunc()
+        sweetAlert({
+            title: Alert.title(
+                'Create Folder',
+                'mdi-folder-plus'
+            ),
+            text: 'Enter a name for your folder:',
+            input: 'text',
+            inputValue: '',
+            confirmButtonText: 'Create',
+            showCancelButton: true,
+        }).then(result => {
+            if (!result.value) {
+                return;
+            }
 
-        let node = $('#directoryTree').tree('getSelectedNode')
-        const type = 'directory'
-        const name = result.value
+            sweetAlert.close();
+            const data = new FormData();
+            data.append('mode', buildMode);
 
-        if (!node) {
-          node = $('#directoryTree').tree('getTree')
-        }
-        if (node.type !== 'directory') {
-          node = node.parent
-        }
+            path === '' ?
+                data.append('path', result.value) :
+                data.append('path', `${path}/${result.value}`);
 
-        $('#directoryTree').tree(
-          'appendNode', {
-            id: utils.directoryTree.createNodeId(type, name),
-            name,
-            type,
-            children: [],
-          },
-          node
-        )
+            sendHttp('POST', 'createFolder', data, request => {
+                if (request.status !== 200) {
+                    return sweetAlert(
+                        'Oops',
+                        'Could not create your directory! Please try again.',
+                        'error',
+                    );
+                }
 
-        updateChildrenIndexes(node)
-      })
-    })
-  })
+                successFunc();
+
+                let node = $('#directoryTree').tree('getSelectedNode');
+                const type = 'directory';
+                const name = result.value;
+
+                if (!node) {
+                    node = $('#directoryTree').tree('getTree');
+                }
+                if (node.type !== 'directory') {
+                    node = node.parent;
+                }
+
+                $('#directoryTree').tree(
+                    'appendNode', {
+                        id: utils.directoryTree.createNodeId(type, name),
+                        name,
+                        type,
+                        children: [],
+                    },
+                    node
+                );
+
+                updateChildrenIndexes(node);
+            });
+        });
+    });
 }
 
 function loadProject_(path, name, buildMode, successFunc) {
@@ -1411,8 +1410,8 @@ function shareFolder_(mode) {
         return;
     }
     if (!getNearestDirectory() || utils.directoryTree.getCurrentProjectName()) {
-      sweetAlert('Oops!', 'You must select a folder to share!', 'error')
-      return updateUI()
+        sweetAlert('Oops!', 'You must select a folder to share!', 'error');
+        return updateUI();
     }
 
     const folderName = Html.encode(getNearestDirectory_().name);
@@ -1649,9 +1648,9 @@ function initDirectoryTree() {
         closedIcon: $('<i class="mdi mdi-18px mdi-chevron-right"></i>'),
         openedIcon: $('<i class="mdi mdi-18px mdi-chevron-down"></i>'),
         onCreateLi: function(node, $li) {
-          const titleElem = $li.find('.jqtree-element .jqtree-title');
+            const titleElem = $li.find('.jqtree-element .jqtree-title');
 
-          if (node.type === 'directory' && node.is_open) {
+            if (node.type === 'directory' && node.is_open) {
                 titleElem.before(
                     $('<i class="mdi mdi-18px mdi-folder-open"></i>')
                 );

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -956,6 +956,30 @@ function moveDirTreeNode(moveFrom, moveTo, isFile, name, buildMode, successFunc)
     });
 }
 
+function setCode(code, history, name, autostart) {
+    if (!window.codeworldEditor) {
+        return;
+    }
+
+    const doc = window.codeworldEditor.getDoc();
+    doc.setValue(code);
+    window.savedGeneration = doc.changeGeneration(true);
+
+    if (history) {
+        doc.setHistory(history);
+    } else {
+        doc.clearHistory();
+    }
+
+    window.codeworldEditor.focus();
+    parseSymbolsFromCurrentCode();
+    if (autostart) {
+        compile();
+    } else {
+        stopRun();
+    }
+}
+
 function warnIfUnsaved(action) {
     if (isEditorClean()) {
         action();
@@ -993,12 +1017,10 @@ function saveProjectAsBase(successFunc) {
                     .text(getNearestDirectory())
                     .html()
                     .replace(/ /g, '&nbsp;')
-            }:` :
-            'Enter a name for your project:',
+            }:` : 'Enter a name for your project:',
         input: 'text',
         inputValue: selectedNode && !isDirectoryNode ?
-            selectedNode.name :
-            '',
+            selectedNode.name : '',
         confirmButtonText: 'Save',
         showCancelButton: true,
         closeOnConfirm: false,
@@ -1924,4 +1946,18 @@ function updateChildrenIndexes(node) {
         data.append('entries', JSON.stringify(repacked));
         sendHttp('POST', 'updateChildrenIndexes', data, () => {});
     } else updateUI();
+}
+
+function updateTreeOnNewProjectCreation() {
+    const selectedNode = getSelectedNode();
+
+    if (selectedNode && utils.directoryTree.isProject(selectedNode)) {
+        utils.directoryTree.clearSelectedNode();
+
+        // Select parent folder (if any) as new project's location is
+        // determined by the selection in the directory tree.
+        if (pathToRootDir(selectedNode)) {
+            utils.directoryTree.selectNode(selectedNode.parent);
+        }
+    }
 }

--- a/web/js/funblocks.js
+++ b/web/js/funblocks.js
@@ -119,11 +119,11 @@ function initCodeworld() {
 }
 
 function getCurrentProject() {
-  return {
-    name: utils.directoryTree.getCurrentProjectName() || 'Untitled',
-    source: getWorkspaceXMLText(),
-    history: '',
-  }
+    return {
+        name: utils.directoryTree.getCurrentProjectName() || 'Untitled',
+        source: getWorkspaceXMLText(),
+        history: '',
+    };
 }
 
 // Sets the generated code
@@ -317,7 +317,7 @@ function updateUI() {
         document.getElementById('shareFolderButton').style.display = 'none';
     }
 
-    let title = utils.directoryTree.getCurrentProjectName() || '(new)'
+    let title = utils.directoryTree.getCurrentProjectName() || '(new)';
 
     if (!isEditorClean()) {
         title = `* ${title}`;
@@ -374,23 +374,23 @@ function saveProject() {
         window.lastXML = getWorkspaceXMLText();
     }
 
-    const currentProjectName = utils.directoryTree.getCurrentProjectName()
+    const currentProjectName = utils.directoryTree.getCurrentProjectName();
 
     if (currentProjectName) {
-      saveProjectBase(
-        getNearestDirectory(),
-        currentProjectName,
-        window.projectEnv,
-        successFunc,
-      )
+        saveProjectBase(
+            getNearestDirectory(),
+            currentProjectName,
+            window.projectEnv,
+            successFunc,
+        );
     } else {
-      saveProjectAs()
+        saveProjectAs();
     }
 }
 
 function saveProjectAs() {
     function successFunc(name) {
-      window.lastXML = getWorkspaceXMLText();
+        window.lastXML = getWorkspaceXMLText();
     }
     saveProjectAsBase(successFunc);
 }
@@ -398,10 +398,10 @@ function saveProjectAs() {
 function deleteFolder() {
     const path = getNearestDirectory();
     if (
-      path === '' ||
-      utils.directoryTree.getCurrentProjectName() !== null
+        path === '' ||
+        utils.directoryTree.getCurrentProjectName() !== null
     ) {
-      return
+        return;
     }
 
     function successFunc() {
@@ -413,7 +413,7 @@ function deleteFolder() {
 
 function deleteProject() {
     if (!utils.directoryTree.getCurrentProjectName()) {
-        return deleteFolder()
+        return deleteFolder();
     }
 
     function successFunc() {
@@ -457,13 +457,13 @@ function clearRunCode() {
 }
 
 function clearWorkspace() {
-  const workspace = Blockly.mainWorkspace;
+    const workspace = Blockly.mainWorkspace;
 
-  utils.directoryTree.clearSelectedNode()
-  workspace.clear();
+    utils.directoryTree.clearSelectedNode();
+    workspace.clear();
 }
 
 function clearCode() {
-  const workspace = Blockly.mainWorkspace
-  workspace.clear()
+    const workspace = Blockly.mainWorkspace;
+    workspace.clear();
 }

--- a/web/js/funblocks.js
+++ b/web/js/funblocks.js
@@ -15,7 +15,6 @@
  */
 'use strict';
 
-window.openProjectName = '';
 window.lastXML = '';
 
 // This will get bound in Haskell to a function that runs the program
@@ -120,11 +119,11 @@ function initCodeworld() {
 }
 
 function getCurrentProject() {
-    return {
-        'name': window.openProjectName || 'Untitled',
-        'source': getWorkspaceXMLText(),
-        'history': ''
-    };
+  return {
+    name: utils.directoryTree.getCurrentProjectName() || 'Untitled',
+    source: getWorkspaceXMLText(),
+    history: '',
+  }
 }
 
 // Sets the generated code
@@ -290,7 +289,7 @@ function updateUI() {
         } else {
             document.getElementById('deleteButton').style.display = 'none';
         }
-        if (window.openProjectName) {
+        if (utils.directoryTree.getCurrentProjectName()) {
             document.getElementById('saveButton').style.display = '';
         } else {
             document.getElementById('saveButton').style.display = 'none';
@@ -318,12 +317,7 @@ function updateUI() {
         document.getElementById('shareFolderButton').style.display = 'none';
     }
 
-    let title;
-    if (window.openProjectName) {
-        title = window.openProjectName;
-    } else {
-        title = '(new)';
-    }
+    let title = utils.directoryTree.getCurrentProjectName() || '(new)'
 
     if (!isEditorClean()) {
         title = `* ${title}`;
@@ -344,7 +338,7 @@ function updateUI() {
 function help() {
     const url = 'doc.html?shelf=help/blocks.shelf';
     sweetAlert({
-        html: `<iframe id="doc" style="width: 100%; height: 100%" class="dropbox" src="${ 
+        html: `<iframe id="doc" style="width: 100%; height: 100%" class="dropbox" src="${
             url}"></iframe>`,
         customClass: 'helpdoc',
         allowEscapeKey: true,
@@ -358,18 +352,15 @@ function signinCallback() {
 }
 
 function signOut() {
-
     // call shared sign out
     signout();
 
     document.getElementById('projects').innerHTML = '';
-    window.openProjectName = null;
     updateUI();
 }
 
 function loadProject(name, index) {
     function successFunc(project) {
-        window.openProjectName = name;
         clearRunCode();
         loadWorkspace(project.source);
         Blockly.getMainWorkspace().clearUndo();
@@ -383,29 +374,34 @@ function saveProject() {
         window.lastXML = getWorkspaceXMLText();
     }
 
-    if (window.openProjectName) {
-        saveProjectBase(
-            getNearestDirectory(),
-            window.openProjectName,
-            window.projectEnv,
-            successFunc);
+    const currentProjectName = utils.directoryTree.getCurrentProjectName()
+
+    if (currentProjectName) {
+      saveProjectBase(
+        getNearestDirectory(),
+        currentProjectName,
+        window.projectEnv,
+        successFunc,
+      )
     } else {
-        saveProjectAs();
+      saveProjectAs()
     }
 }
 
 function saveProjectAs() {
     function successFunc(name) {
-        window.lastXML = getWorkspaceXMLText();
-        window.openProjectName = name;
+      window.lastXML = getWorkspaceXMLText();
     }
     saveProjectAsBase(successFunc);
 }
 
 function deleteFolder() {
     const path = getNearestDirectory();
-    if (path === '' || window.openProjectName !== null) {
-        return;
+    if (
+      path === '' ||
+      utils.directoryTree.getCurrentProjectName() !== null
+    ) {
+      return
     }
 
     function successFunc() {
@@ -416,9 +412,8 @@ function deleteFolder() {
 }
 
 function deleteProject() {
-    if (!window.openProjectName) {
-        deleteFolder();
-        return;
+    if (!utils.directoryTree.getCurrentProjectName()) {
+        return deleteFolder()
     }
 
     function successFunc() {
@@ -462,17 +457,13 @@ function clearRunCode() {
 }
 
 function clearWorkspace() {
-    window.openProjectName = null;
-    const workspace = Blockly.mainWorkspace;
-    // Deselect nodes
-    const treeState = $('#directoryTree').tree('getState');
-    treeState.selected_node = [];
-    $('#directoryTree').tree('setState', treeState);
-    workspace.clear();
+  const workspace = Blockly.mainWorkspace;
+
+  utils.directoryTree.clearSelectedNode()
+  workspace.clear();
 }
 
 function clearCode() {
-    window.openProjectName = null;
-    const workspace = Blockly.mainWorkspace;
-    workspace.clear();
+  const workspace = Blockly.mainWorkspace
+  workspace.clear()
 }

--- a/web/js/funblocks.js
+++ b/web/js/funblocks.js
@@ -395,15 +395,12 @@ function saveProjectAs() {
 
 function deleteFolder() {
     const path = getNearestDirectory();
-    if (
-        path === '' ||
-        utils.directoryTree.getSelectedNode() !== null
-    ) {
+    if (!path) {
         return;
     }
 
     function successFunc() {
-        clearWorkspace();
+        Blockly.mainWorkspace.clear();
         Blockly.getMainWorkspace().clearUndo();
     }
     deleteFolder_(path, window.projectEnv, successFunc);
@@ -417,7 +414,7 @@ function deleteProject() {
     }
 
     function successFunc() {
-        clearWorkspace();
+        Blockly.mainWorkspace.clear();
         Blockly.getMainWorkspace().clearUndo();
     }
     const path = getNearestDirectory();
@@ -440,8 +437,9 @@ function shareFolder() {
 
 function newProject() {
     warnIfUnsaved(() => {
+        updateTreeOnNewProjectCreation();
         clearRunCode();
-        clearWorkspace();
+        Blockly.mainWorkspace.clear();
         updateUI();
         window.lastXML = getWorkspaceXMLText();
         Blockly.getMainWorkspace().clearUndo();
@@ -454,13 +452,6 @@ function clearRunCode() {
     const runner = document.getElementById('runner');
     runner.contentWindow.location.replace('about:blank');
     updateEditor('');
-}
-
-function clearWorkspace() {
-    const workspace = Blockly.mainWorkspace;
-
-    utils.directoryTree.clearSelectedNode();
-    workspace.clear();
 }
 
 function clearCode() {

--- a/web/js/funblocks.js
+++ b/web/js/funblocks.js
@@ -410,7 +410,8 @@ function deleteProject() {
     const selectedNode = utils.directoryTree.getSelectedNode();
 
     if (selectedNode && utils.directoryTree.isDirectory(selectedNode)) {
-        return deleteFolder();
+        deleteFolder();
+        return;
     }
 
     function successFunc() {

--- a/web/js/funblocks.js
+++ b/web/js/funblocks.js
@@ -119,8 +119,9 @@ function initCodeworld() {
 }
 
 function getCurrentProject() {
+    const selectedNode = utils.directoryTree.getSelectedNode();
     return {
-        name: utils.directoryTree.getCurrentProjectName() || 'Untitled',
+        name: selectedNode ? selectedNode.name : 'Untitled',
         source: getWorkspaceXMLText(),
         history: '',
     };
@@ -275,6 +276,8 @@ function compile(src, silent) {
  */
 function updateUI() {
     const isSignedIn = signedIn();
+    const selectedNode = utils.directoryTree.getSelectedNode();
+
     if (isSignedIn) {
         if (document.getElementById('signout').style.display === 'none') {
             document.getElementById('signin').style.display = 'none';
@@ -284,14 +287,11 @@ function updateUI() {
             window.mainLayout.open('west');
         }
 
-        if ($('#directoryTree').tree('getSelectedNode')) {
+        if (selectedNode) {
             document.getElementById('deleteButton').style.display = '';
-        } else {
-            document.getElementById('deleteButton').style.display = 'none';
-        }
-        if (utils.directoryTree.getCurrentProjectName()) {
             document.getElementById('saveButton').style.display = '';
         } else {
+            document.getElementById('deleteButton').style.display = 'none';
             document.getElementById('saveButton').style.display = 'none';
         }
     } else {
@@ -309,21 +309,19 @@ function updateUI() {
     document.getElementById('saveAsButton').style.display = '';
     document.getElementById('runButtons').style.display = '';
 
-    const selected = $('#directoryTree').tree('getSelectedNode');
-
-    if (selected && selected.type === 'directory') {
+    if (selectedNode && utils.directoryTree.isDirectory(selectedNode)) {
         document.getElementById('shareFolderButton').style.display = '';
     } else {
         document.getElementById('shareFolderButton').style.display = 'none';
     }
 
-    let title = utils.directoryTree.getCurrentProjectName() || '(new)';
+    let title = selectedNode ? selectedNode.name : '(new)';
 
     if (!isEditorClean()) {
         title = `* ${title}`;
-        const selected = $('#directoryTree').tree('getSelectedNode');
-        if (selected && selected.type === 'project') {
-            const asterisk = selected.element.getElementsByClassName('unsaved-changes')[0];
+
+        if (selectedNode && utils.directoryTree.isProject(selectedNode)) {
+            const asterisk = selectedNode.element.getElementsByClassName('unsaved-changes')[0];
             if (asterisk) {
                 asterisk.style.display = '';
             }
@@ -374,12 +372,12 @@ function saveProject() {
         window.lastXML = getWorkspaceXMLText();
     }
 
-    const currentProjectName = utils.directoryTree.getCurrentProjectName();
+    const selectedNode = utils.directoryTree.getSelectedNode();
 
-    if (currentProjectName) {
+    if (selectedNode) {
         saveProjectBase(
             getNearestDirectory(),
-            currentProjectName,
+            selectedNode.name,
             window.projectEnv,
             successFunc,
         );
@@ -399,7 +397,7 @@ function deleteFolder() {
     const path = getNearestDirectory();
     if (
         path === '' ||
-        utils.directoryTree.getCurrentProjectName() !== null
+        utils.directoryTree.getSelectedNode() !== null
     ) {
         return;
     }
@@ -412,7 +410,9 @@ function deleteFolder() {
 }
 
 function deleteProject() {
-    if (!utils.directoryTree.getCurrentProjectName()) {
+    const selectedNode = utils.directoryTree.getSelectedNode();
+
+    if (selectedNode && utils.directoryTree.isDirectory(selectedNode)) {
         return deleteFolder();
     }
 

--- a/web/js/utils/directoryTree.js
+++ b/web/js/utils/directoryTree.js
@@ -1,0 +1,34 @@
+const directoryTreeId = '#directoryTree'
+
+function clearSelectedNode() {
+  const directoryTree = $(directoryTreeId)
+
+  const state = directoryTree.tree('getState')
+  state.selected_node = []
+  directoryTree.tree('setState', state)
+}
+
+function createNodeId(type, name) {
+  return `jqtree-element__${type}__${name}`
+}
+
+function getCurrentProjectName() {
+  const directoryTree = $(directoryTreeId)
+  
+  const state = directoryTree.tree('getState')
+  const selectedNodeId = state.selected_node[0]
+
+  if (!selectedNodeId) {
+    return null
+  }
+
+  const { name } = directoryTree.tree('getNodeById', selectedNodeId)
+
+  return name
+}
+
+window.utils.directoryTree = {
+  clearSelectedNode,
+  createNodeId,
+  getCurrentProjectName
+}

--- a/web/js/utils/directoryTree.js
+++ b/web/js/utils/directoryTree.js
@@ -1,34 +1,38 @@
-const directoryTreeId = '#directoryTree'
+'use strict'
+
+const directoryTreeId = '#directoryTree';
 
 function clearSelectedNode() {
-  const directoryTree = $(directoryTreeId)
+    const directoryTree = $(directoryTreeId);
 
-  const state = directoryTree.tree('getState')
-  state.selected_node = []
-  directoryTree.tree('setState', state)
+    const state = directoryTree.tree('getState');
+    state.selected_node = [];
+    directoryTree.tree('setState', state);
 }
 
 function createNodeId(type, name) {
-  return `jqtree-element__${type}__${name}`
+    return `jqtree-element__${type}__${name}`;
 }
 
 function getCurrentProjectName() {
-  const directoryTree = $(directoryTreeId)
-  
-  const state = directoryTree.tree('getState')
-  const selectedNodeId = state.selected_node[0]
+    const directoryTree = $(directoryTreeId);
 
-  if (!selectedNodeId) {
-    return null
-  }
+    const state = directoryTree.tree('getState');
+    const selectedNodeId = state.selected_node[0];
 
-  const { name } = directoryTree.tree('getNodeById', selectedNodeId)
+    if (!selectedNodeId) {
+        return null;
+    }
 
-  return name
+    const {
+        name
+    } = directoryTree.tree('getNodeById', selectedNodeId);
+
+    return name;
 }
 
 window.utils.directoryTree = {
-  clearSelectedNode,
-  createNodeId,
-  getCurrentProjectName
-}
+    clearSelectedNode,
+    createNodeId,
+    getCurrentProjectName
+};

--- a/web/js/utils/directoryTree.js
+++ b/web/js/utils/directoryTree.js
@@ -18,9 +18,11 @@ function selectNode(node) {
     $(directoryTreeId).tree('selectNode', node);
 }
 
+let idCounter = 0;
 function createNodeId(type, name) {
+
     return (
-        `jqtree-element__${type}__${name}__${Math.floor(Math.random() * 1000000)}`
+        `jqtree-element__${type}__${name}__${idCounter++}}`
     );
 }
 

--- a/web/js/utils/directoryTree.js
+++ b/web/js/utils/directoryTree.js
@@ -1,6 +1,10 @@
-'use strict'
+'use strict';
 
 const directoryTreeId = '#directoryTree';
+const nodeTypes = {
+    DIRECTORY: 'directory',
+    PROJECT: 'project',
+};
 
 function clearSelectedNode() {
     const directoryTree = $(directoryTreeId);
@@ -10,29 +14,40 @@ function clearSelectedNode() {
     directoryTree.tree('setState', state);
 }
 
-function createNodeId(type, name) {
-    return `jqtree-element__${type}__${name}`;
+function selectNode(node) {
+    $(directoryTreeId).tree('selectNode', node);
 }
 
-function getCurrentProjectName() {
-    const directoryTree = $(directoryTreeId);
+function createNodeId(type, name) {
+    return (
+        `jqtree-element__${type}__${name}__${Math.floor(Math.random() * 1000000)}`
+    );
+}
 
-    const state = directoryTree.tree('getState');
-    const selectedNodeId = state.selected_node[0];
+function getSelectedNode() {
+    const node = $(directoryTreeId).tree('getSelectedNode');
 
-    if (!selectedNodeId) {
-        return null;
-    }
+    return node ? node : null;
+}
 
-    const {
-        name
-    } = directoryTree.tree('getNodeById', selectedNodeId);
+function isDirectory(node) {
+    return node ?
+        node.type === nodeTypes.DIRECTORY :
+        false;
+}
 
-    return name;
+function isProject(node) {
+    return node ?
+        node.type === nodeTypes.PROJECT :
+        false;
 }
 
 window.utils.directoryTree = {
-    clearSelectedNode,
     createNodeId,
-    getCurrentProjectName
+    selectNode,
+    clearSelectedNode,
+    getSelectedNode,
+    isDirectory,
+    isProject,
+    nodeTypes
 };

--- a/web/js/utils/index.js
+++ b/web/js/utils/index.js
@@ -1,3 +1,3 @@
-'use strict'
+'use strict';
 
 window.utils = {};

--- a/web/js/utils/index.js
+++ b/web/js/utils/index.js
@@ -1,0 +1,1 @@
+window.utils = {}

--- a/web/js/utils/index.js
+++ b/web/js/utils/index.js
@@ -1,1 +1,3 @@
-window.utils = {}
+'use strict'
+
+window.utils = {};


### PR DESCRIPTION
This commit eliminates `window.openProjectName` property. Rely on directory tree state to determine the name of the currently open project instead.