### PR TITLE
Set up formatting&linting in pre-commit hook (#1375)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,7 +11,7 @@ parserOptions:
 rules:
   indent:
     - error
-    - 4
+    - 2
   linebreak-style:
     - error
     - unix

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -euo pipefail
+
+FILES_PRETTIER=$(git diff --cached --name-only --diff-filter=ACMR "*.js" "*.css" "*.html" "*.json" | sed 's| |\\ |g')
+FILES_ESLINT=$(git diff --cached --name-only --diff-filter=ACMR "*.js" | sed 's| |\\ |g')
+FILES_ORMOLU=$(git diff --cached --name-only --diff-filter=ACMR "*.hs" | sed 's| |\\ |g')
+
+echo "Reprinting any staged JS, CSS and HTML files with Prettier ..."
+echo "$FILES_PRETTIER" | xargs npx prettier --write
+echo "Reprinting complete."
+echo "Linting any staged JS files with ESLint ..."
+echo "$FILES_ESLINT" | xargs npx eslint --fix
+echo "Linting complete."
+echo "Formatting any staged Haskell files with Ormolu ..."
+for f in $FILES_ORMOLU
+do
+    ormolu --mode inplace $f
+done
+echo "Formatting complete."
+
+# Add modified files back to staging
+echo "$FILES_PRETTIER" | xargs git add
+echo "$FILES_ESLINT" | xargs git add
+echo "$FILES_ORMOLU" | xargs git add
+
+exit 0

--- a/format.sh
+++ b/format.sh
@@ -19,15 +19,13 @@ set -euo pipefail
 source base.sh
 
 mkdir -p $BUILD/node_modules
-run $BUILD npm install --silent js-beautify
-run $BUILD npm install --silent eslint
 
 function formatall_js {
-    nodejs build/node_modules/js-beautify/js/bin/js-beautify.js -n -m 2 $(find web/js -regex .*\\.js$ -type f)
-    nodejs build/node_modules/js-beautify/js/bin/css-beautify.js -n $(find web/css -regex .*\\.css$ -type f)
-    nodejs build/node_modules/js-beautify/js/bin/html-beautify.js -n $(find web -regex .*\\.html$ -type f)
+    npx prettier --write $(find web/js -regex .*\\.js$ -type f)
+    npx prettier --write $(find web/css -regex .*\\.css$ -type f)
+    npx prettier --write $(find web -regex .*\\.html$ -type f)
 
-    nodejs build/node_modules/eslint/bin/eslint.js --fix $(find web/js -regex .*\\.js$ -type f) || true
+    npx eslint --fix $(find web/js -regex .*\\.js$ -type f) || true
 }
 
 run . formatall_js

--- a/install.sh
+++ b/install.sh
@@ -253,5 +253,7 @@ fi
 run . git submodule init
 run . git submodule update
 
+run . git config core.hooksPath .githooks
+
 # Go ahead and run a first build, which installs more local packages.
 ./build.sh


### PR DESCRIPTION
I ended up using the [script](https://prettier.io/docs/en/precommit.html#option-6-bash-script) provided by the Prettier team.

It's worth noting that I removed the following part:

`[ -z "$FILES" ] && exit 0`

It caused the script to terminate early without actually doing anything useful. What is the purpose of this statement? Is it important to have it?

Tested on JS, CSS and HTML files. Please verify with Haskell files. Please also let me know if something could be improved as I'm not very fluent in bash scripting.