### PR TITLE
Stylish Haskell config

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,56 @@
+steps:
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      align: none
+
+      list_align: after_alias
+
+      pad_module_names: true
+
+      long_list_align: multiline
+
+      empty_list_align: inherit
+
+      list_padding: 4
+
+      separate_lists: true
+
+      space_surround: false
+
+      ghc_lib_parser: false
+
+  # Language pragmas
+  - language_pragmas:
+      style: vertical
+
+      align: false
+
+      remove_redundant: true
+
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+columns: 80
+
+newline: native
+
+cabal: true

--- a/codeworld-account/src/CodeWorld/Account/Actions.hs
+++ b/codeworld-account/src/CodeWorld/Account/Actions.hs
@@ -31,28 +31,24 @@ where
 
 import qualified CodeWorld.Account.Hashing as Hashing
 import CodeWorld.Account.Types
-import Control.Monad.Trans.State.Strict
-  ( State,
-    execState,
-    modify,
-  )
+import Control.Monad.Trans.State.Strict (State, execState, modify)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as Text (intercalate, pack)
 import Database.SQLite.Simple
-  ( Connection,
-    NamedParam (..),
-    Only (..),
-    Query (..),
-    SQLData (..),
-    execute,
-    executeNamed,
-    execute_,
-    queryNamed,
-    query_,
-    withConnection,
-    withTransaction,
-  )
+    ( Connection
+    , NamedParam (..)
+    , Only (..)
+    , Query (..)
+    , SQLData (..)
+    , execute
+    , executeNamed
+    , execute_
+    , queryNamed
+    , query_
+    , withConnection
+    , withTransaction
+    )
 import Database.SQLite.Simple.ToField (ToField (..))
 import System.Directory (doesFileExist)
 
@@ -95,7 +91,7 @@ updateAccount store (UserId userIdRaw) mbStatus mbPasswordHash =
       (q, ps) = renderInsert "accounts" "userId" (SQLText $ Text.pack userIdRaw) params
    in case ps of
         [_] -> pure ()
-        _ -> withStore store $ \conn -> executeNamed conn q ps
+        _   -> withStore store $ \conn -> executeNamed conn q ps
 
 deleteAccount :: Store -> UserId -> IO ()
 deleteAccount store (UserId userIdRaw) =
@@ -145,8 +141,8 @@ incrementTokenId store (UserId userIdRaw) = withStore store $ \conn -> do
       params
   case result of
     [(Only tokenIdRaw)] -> return $ Just (TokenId tokenIdRaw)
-    [] -> return Nothing
-    _ -> error "Assertion failure"
+    []                  -> return Nothing
+    _                   -> error "Assertion failure"
 
 -- | Verifies that token ID is valid for active user
 verifyTokenId ::

--- a/codeworld-account/src/CodeWorld/Account/Hashing.hs
+++ b/codeworld-account/src/CodeWorld/Account/Hashing.hs
@@ -22,10 +22,10 @@ where
 
 import CodeWorld.Account.Types
 import Crypto.BCrypt
-  ( hashPasswordUsingPolicy,
-    slowerBcryptHashingPolicy,
-    validatePassword,
-  )
+    ( hashPasswordUsingPolicy
+    , slowerBcryptHashingPolicy
+    , validatePassword
+    )
 import qualified Data.ByteString.Char8 as Char8 (pack)
 
 -- | Hashes a password using default bcrypt algorithm
@@ -37,7 +37,7 @@ hash ::
 hash (Password passwordRaw) = do
   mbPasswordHashRaw <- hashPasswordUsingPolicy slowerBcryptHashingPolicy (Char8.pack passwordRaw)
   case mbPasswordHashRaw of
-    Nothing -> error "Assertion failed"
+    Nothing              -> error "Assertion failed"
     Just passwordHashRaw -> return $ PasswordHash passwordHashRaw
 
 -- | Validates a password against a bcrypt password hash


### PR DESCRIPTION
This Stylish Haskell configuration formats the code similarly to how it already is. I've formatted two files to show the differences. There may be other differences, as well.

The differences could be reduced further by disabling the `simple_align` settings.

Footnote for Emacs users: I've tested this to work with `haskell-mode-format-imports` (https://github.com/haskell/haskell-mode/blob/886795c15036d566aeced66f9508ae61ec0287ec/haskell-mode.el#L1069)