### PR TITLE
fix non-GHCJS compilation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,6 @@ packages:
   codeworld-server/
   codeworld-base/
   funblocks-client/
+
+constraints:
+  ghcjs-dom ==0.9.5.0

--- a/codeworld-auth/codeworld-auth.cabal
+++ b/codeworld-auth/codeworld-auth.cabal
@@ -31,7 +31,7 @@ library
                                           , directory
                                           , filepath
                                           , http-conduit
-                                          , jwt >= 0.10.0
+                                          , jwt == 0.10.*
                                           , snap-core
                                           , split
                                           , text


### PR DESCRIPTION
With GHC 8.6.5 this succeeds locally for me:
```
% cabal build all
Up to date
```